### PR TITLE
[WIP] Kopia restore command

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.go	whitespace=trailing-space,space-before-tab,indent-with-non-tab
+go.mod	whitespace=trailing-space,space-before-tab,indent-with-non-tab

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM kanisterio/kanister-tools:0.20.0
+
+COPY ./kopia /usr/local/bin/kopia
+
+CMD [ "/usr/bin/tail", "-f", "/dev/null" ]

--- a/cli/app.go
+++ b/cli/app.go
@@ -27,6 +27,7 @@ var (
 	repositoryCommands = app.Command("repository", "Commands to manipulate repository.").Alias("repo")
 	cacheCommands      = app.Command("cache", "Commands to manipulate local cache").Hidden()
 	snapshotCommands   = app.Command("snapshot", "Commands to manipulate snapshots.").Alias("snap")
+	restoreCommands    = app.Command("restore", "Commands to restore snapshots.")
 	policyCommands     = app.Command("policy", "Commands to manipulate snapshotting policies.").Alias("policies")
 	serverCommands     = app.Command("server", "Commands to control HTTP API server.")
 	manifestCommands   = app.Command("manifest", "Low-level commands to manipulate manifest items.").Hidden()

--- a/cli/command_restore.go
+++ b/cli/command_restore.go
@@ -1,0 +1,81 @@
+package cli
+
+import (
+	"context"
+	"io"
+	"os"
+	"path"
+
+	"github.com/kopia/kopia/repo"
+	"github.com/kopia/kopia/repo/object"
+	"github.com/kopia/kopia/snapshot/snapshotfs"
+)
+
+var (
+	restoreSnapshotID = restoreCommands.Arg("snapshot-id", "Snapshot ID from which to restore.").Required().String()
+	restoreTargetPath = restoreCommands.Arg("target-path", "Path to which the snapshot must be restored.").Required().String()
+)
+
+func runRestoreCommand(ctx context.Context, rep *repo.Repository) error {
+	oid, err := parseObjectID(ctx, rep, *restoreSnapshotID)
+	if err != nil {
+		return err
+	}
+	targetPath := *restoreTargetPath
+
+	return restoreRecursively(ctx, rep, targetPath, oid)
+}
+
+func init() {
+	restoreCommands.Action(repositoryAction(runRestoreCommand))
+}
+
+func restoreRecursively(ctx context.Context, rep *repo.Repository, targetPath string, oid object.ID) error {
+	d := snapshotfs.DirectoryEntry(rep, oid, nil)
+
+	entries, err := d.Readdir(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, e := range entries {
+		restorePath := path.Join(targetPath, e.Name())
+		objectID := e.(object.HasObjectID).ObjectID()
+		// Restore directories recursively
+		if e.Mode().IsDir() {
+			// Create the directory
+			if direrr := os.MkdirAll(restorePath, 0777); direrr != nil {
+				return direrr
+			}
+			if recerr := restoreRecursively(ctx, rep, restorePath+"/", objectID); recerr != nil {
+				return recerr
+			}
+			// Set permissions as stored in the backup
+			if cherr := os.Chmod(restorePath, e.Mode()); cherr != nil {
+				return cherr
+			}
+			continue
+		}
+		// Create the output file
+		outFile, err := os.Create(restorePath)
+		if err != nil {
+			return err
+		}
+		defer outFile.Close() //nolint:errcheck
+		// Open the repo object and copy data into the new file
+		r, err := rep.Objects.Open(ctx, objectID)
+		if err != nil {
+			return err
+		}
+		defer r.Close() //nolint:errcheck
+		if _, cerr := io.Copy(outFile, r); cerr != nil {
+			return cerr
+		}
+		// Set file permissions as stored in the backup
+		if cherr := os.Chmod(outFile.Name(), e.Mode()); cherr != nil {
+			return cherr
+		}
+	}
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/op/go-logging v0.0.0-20160315200505-970db520ece7
 	github.com/pkg/errors v0.8.1
+	github.com/pkg/profile v1.3.0
 	github.com/pkg/sftp v1.10.1
 	github.com/skratchdot/open-golang v0.0.0-20190402232053-79abb63cd66e
 	github.com/studio-b12/gowebdav v0.0.0-20190103184047-38f79aeaf1ac

--- a/site/content/docs/Encryption/_index.md
+++ b/site/content/docs/Encryption/_index.md
@@ -1,0 +1,105 @@
+---
+title: "Encryption"
+linkTitle: "Encryption"
+weight: 4
+---
+
+### Format Blob Encryption
+
+Kopia uses a standard envelope encryption technique to de-couple the repository passphrase from the keys used for encrypting and authenticating the contents of the repository.
+
+Each repository has a format blob containing configuration parameters for the repository. The format blob itself is serialized and persistent as JSON, such as the one below.
+
+```json
+{
+  "tool": "https://github.com/kopia/kopia",
+  "buildVersion": "v0.3.0",
+  "buildInfo": "unknown",
+  "uniqueID": "bm90IGEgZ29vZCByYW5kb20gaW5pdGlhbCB2YWx1ZQ==",
+  "keyAlgo": "scrypt-65536-8-1",
+  "version": "1",
+  "encryption": "AES256_GCM",
+  "encryptedBlockFormat": "ZSxqt/gXwVPS6pNvFZOOHlCKr18TmziuUnN8nnuvwQ/+mjbcvEHUfKS11RJl/sWrIOyiYqpSwAZt
+BzOxQAUWQt7vHc2ZT4Y75ODrPHhzd0CcBlqHa3HSx8pxIXqpgMy5K3xDvIkBN1qdb/cTyU5s9lZ2
+J+rBh2CGQ3phIlKFCCuS3lgB+rnYRrExGg5rm4BUmZZWHfBPQ7QiOJNg86PK+n///dejsAA/+FBj
+qIODf7Gr3ppaGZeAHYJuz0BkRSPC4XIAgFj1yPo="
+}
+```
+
+The corresponding Go struct is the following:
+
+```go
+type formatBlob struct {
+	Tool         string `json:"tool"`
+	BuildVersion string `json:"buildVersion"`
+	BuildInfo    string `json:"buildInfo"`
+
+	UniqueID               []byte `json:"uniqueID"`
+	KeyDerivationAlgorithm string `json:"keyAlgo"`
+
+	Version              string                  `json:"version"`
+	EncryptionAlgorithm  string                  `json:"encryption"`
+	EncryptedFormatBytes []byte                  `json:"encryptedBlockFormat,omitempty"`
+	UnencryptedFormat    *repositoryObjectFormat `json:"blockFormat,omitempty"`
+}
+```
+
+* `Version` identifies the version of the format blob.
+* The `tool` and `buildInfo` fields are informational
+* `buildVersion` is the version of Kopia, which is also indirectly used as the repository format version.
+* `UniqueID` is a randomly generated identifier for the repository. This is also used as the input for various encryption operations.
+* `keyAlgo` identifies the password-based key derivation function (PBKDF). Only _scrypt_ with the currently recommended cost parameters (N=65536, r=8, p=1) is supported at the moment. The main purpose of this field is to be able to change and extend the key derivation algorithm in the future. For example, by increasing the cost parameters for _scrypt_ or using a different algorithm altogether.
+* `encryption` identifies the encryption algorithm that was used to encrypt the encryptedBlockFormat field.
+* `encryptedBlockFormat` is a ciphertext containing among others, the encryption secrets and parameters used for encrypting the repository content. Below is additional information about its plaintext content and how it is encrypted.
+* Alternatively, the unencrypted block format parameters can be specified in the the `blockFormat` field.
+
+The `formatBlob.encryptedBlockFormat` field is the result of encrypting a JSON-serialized version of the `encryptedRepositoryConfig` struct shown below. The plaintext version contains the parameters for performing block chunking, as well as for encrypting and authenticating "content" objects.
+
+
+```go
+type encryptedRepositoryConfig struct {
+	Format repositoryObjectFormat `json:"format"`
+}
+
+type repositoryObjectFormat struct {
+	content.FormattingOptions
+	object.Format
+}
+```
+
+```go
+package content
+
+// FormattingOptions describes the rules for formatting contents in repository.
+type FormattingOptions struct {
+	Version     int    `json:"version,omitempty"`     // version number, must be "1"
+	Hash        string `json:"hash,omitempty"`        // identifier of the hash algorithm used
+	Encryption  string `json:"encryption,omitempty"`  // identifier of the encryption algorithm used
+	HMACSecret  []byte `json:"secret,omitempty"`      // HMAC secret used to generate encryption keys
+	MasterKey   []byte `json:"masterKey,omitempty"`   // master encryption key (SIV-mode encryption only)
+	MaxPackSize int    `json:"maxPackSize,omitempty"` // maximum size of a pack object
+}
+```
+
+```go
+package object
+
+type Format struct {
+	Splitter string `json:"splitter,omitempty"` // splitter used to break objects into pieces of content
+}
+```
+
+The ciphertext in `formatBlob.encryptedBlockFormat` is obtained by:
+
+1. Serializing to JSON the populated encryptedRepositoryConfig struct.
+2. Encrypting the resulting byte stream with the algorithm specified in `formatBlob.encryption`. At the moment, `AES256_GCM` is used by default, which is both encrypted and authenticated. The input parameters are:
+    * "Plaintext": serialized JSON byte stream
+    * "IV": randomly generated and prepended to the ciphertext in `formatBlob.encryptedBlockFormat`
+    * Key: 256-bit AES encryption key derived from the passphrase, details below.
+    * Additional Data (AD): Used as "authentication data", the value is derived from the passphrase as well. See below.
+
+The passphrase is used to generate the encryption key and _additional data_ (AD) for the encryption and decryption of `formatBlob.encryptedBlockFormat` ciphertext as follows:
+
+* A master key (Km) is derived from the password by using (a) the password-based key derivation function specified in `formatBlob.keyAlgo`, and (b) `formatBlob.UniqueID` as the salt. The resulting key is 32-bytes long (256 bits). `Km = PBKDF( passphrase, formatBlob.UniqueID, … cost parameters)`.
+* The AES-256 encryption key (Ke) is derived from Km by using a hash-based key derivation function (HKDF), with SHA256 as the hash. `Ke = HKDF(SHA256, Km, formatBlob.UniqueID, "AES", 32)`
+* The additional data (AD) is derived using an HKDF as follows: `AD = HKDF(SHA256, Km, formatBlob.UniqueID, "CHECKSUM", 32)`


### PR DESCRIPTION
## Change Overview
```
bash-4.4# kopia restore --help
usage: kopia restore <root-id> <target-path>

Commands to restore snapshots.

Flags:
      --help                  Show context-sensitive help (also try --help-long and --help-man).
      --help-full             Show help for all commands, including hidden
      --trace-object-manager  Enables tracing of object manager operations.
      --trace-localfs         Enables tracing of local filesystem operations
      --config-file="/Users/pdevaraj/Library/Application Support/kopia/repository.config"
                              Specify the config file to use.
  -p, --password=PASSWORD     Repository password.
      --use-keychain          Use macOS Keychain for storing repository password.
      --log-file=LOG-FILE     Log file name.
      --log-dir="/Users/pdevaraj/Library/Logs/kopia"
                              Directory where log files should be written.
      --log-level=info        Console log level
      --file-log-level=info   File log level
      --version               Show application version.

Args:
  <root-id>      Snapshot Root ID from which to restore.
  <target-path>  Path to which the snapshot must be restored.
```
- Walks through all the entries for the given root ID and restores all the files/directories recursively.

Update: Addressed some review comments.

## Pull request type

🚂 Work in Progress

## Test Plan

🚀 Manually backed up and restored a directory structure successfully.

Added checks to prevent override of existing files.
```
pdevaraj @ ~/Work/Kasten/kopia - [restore_test] $ ./kopia restore kf5846e8e0881aea2c5cc4ea8401a8277 ./tmp
pdevaraj @ ~/Work/Kasten/kopia - [restore_test] $ cat ./tmp/f1.txt
afsasfasg
pdevaraj @ ~/Work/Kasten/kopia - [restore_test] $ ./kopia restore kf5846e8e0881aea2c5cc4ea8401a8277 ./tmp
kopia: error: unable to create file: already exists, try --help
```
