### PR TITLE
Restore command

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -7,14 +7,13 @@ import (
 	"os"
 
 	"github.com/pkg/errors"
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/kopia/kopia/internal/kopialogging"
 	"github.com/kopia/kopia/internal/serverapi"
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/content"
-
-	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 
 var log = kopialogging.Logger("kopia/cli")

--- a/cli/command_diff.go
+++ b/cli/command_diff.go
@@ -38,7 +38,7 @@ func runDiffCommand(ctx context.Context, rep *repo.Repository) error {
 		return errors.New("arguments do diff must both be directories or both non-directories")
 	}
 
-	d, err := diff.NewComparer(rep, os.Stdout)
+	d, err := diff.NewComparer(os.Stdout)
 	if err != nil {
 		return err
 	}

--- a/cli/command_restore.go
+++ b/cli/command_restore.go
@@ -1,0 +1,43 @@
+package cli
+
+import (
+	"context"
+
+	"github.com/kopia/kopia/repo"
+	"github.com/kopia/kopia/snapshot/snapshotfs"
+)
+
+const restoreCommandHelp = `Restore a directory from a snapshot into the specified target path.
+
+The target path must not exist and it is created by the restore command. The case when the target is the root directory in the local machine is an exception, in this case no attempt is made to create the root directory and the contents of the source directory are copied to the local root directory.
+The restore command conservatively refuses to overwrite previously existing files or directories.
+
+The source to be restored is specified in the form of a directory ID and optionally a sub-directory path.
+
+For example, the following source and target arguments will restore the contents of the 'kffbb7c28ea6c34d6cbe555d1cf80faa9' directory into a new, local directory named 'd1'
+
+'restore kffbb7c28ea6c34d6cbe555d1cf80faa9 d1'
+
+Similarly, the following command will restore the contents of a subdirectory 'subdir/subdir2' under 'kffbb7c28ea6c34d6cbe555d1cf80faa9'  into a new, local directory named 'sd2'
+
+'restore kffbb7c28ea6c34d6cbe555d1cf80faa9/subdir1/subdir2 sd2'
+`
+
+var (
+	restoreCommand           = app.Command("restore", restoreCommandHelp)
+	restoreCommandSourcePath = restoreCommand.Arg("source-path", "Source directory ID/path in the form of a directory ID and optionally a sub-directory path. For example, ' kffbb7c28ea6c34d6cbe555d1cf80faa9' or 'kffbb7c28ea6c34d6cbe555d1cf80faa9/subdir1/subdir2'").Required().String()
+	restoreCommandTargetPath = restoreCommand.Arg("target-path", "Path of the directory for the contents to be restored").Required().String()
+)
+
+func runRestoreCommand(ctx context.Context, rep *repo.Repository) error {
+	oid, err := parseObjectID(ctx, rep, *restoreCommandSourcePath)
+	if err != nil {
+		return err
+	}
+
+	return snapshotfs.Restore(ctx, rep, *restoreCommandTargetPath, oid)
+}
+
+func init() {
+	restoreCommand.Action(repositoryAction(runRestoreCommand))
+}

--- a/fs/localfs/copy.go
+++ b/fs/localfs/copy.go
@@ -1,0 +1,164 @@
+package localfs
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/fs"
+)
+
+// Copy copies e into targetPath in the local file system. If e is an
+// fs.Directory, then the contents are recursively copied.
+// The targetPath must not exist, except when the target path is the root
+// directory. In that case, e must be a fs.Directory and its contents are copied
+// to the root directory.
+// Copy does not overwrite files or directories and returns an error in that
+// case. It also returns an error when the the contents cannot be restored,
+// for example due to an I/O error.
+func Copy(ctx context.Context, targetPath string, e fs.Entry) error {
+	targetPath, err := filepath.Abs(filepath.FromSlash(targetPath))
+	if err != nil {
+		return err
+	}
+
+	root, err := filepath.Abs(filepath.FromSlash("/"))
+	if err != nil {
+		return err
+	}
+
+	// special case when the target is the root directory
+	if targetPath == root {
+		if d, ok := e.(fs.Directory); ok {
+			return copyDirectoryContent(ctx, d, targetPath)
+		}
+
+		return errors.Errorf("cannot restore non-directory to root target path %q: %#v", targetPath, e)
+	}
+
+	return copyEntry(ctx, e, targetPath)
+}
+
+func copyEntry(ctx context.Context, e fs.Entry, targetPath string) error {
+	var err error
+
+	switch e := e.(type) {
+	case fs.Directory:
+		err = copyDirectory(ctx, e, targetPath)
+	case fs.File:
+		err = copyFileContent(ctx, targetPath, e)
+	case fs.Symlink:
+		// Not yet implemented
+		log.Warningf("Not creating symlink %q from %v", targetPath, e)
+		return nil
+	default:
+		return errors.Errorf("invalid FS entry type for %q: %#v", targetPath, e)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	return setAttributes(targetPath, e)
+}
+
+// set permission, modification time and user/group ids on targetPath
+func setAttributes(targetPath string, e fs.Entry) error {
+	const modBits = os.ModePerm | os.ModeSetgid | os.ModeSetuid | os.ModeSticky
+
+	le, err := NewEntry(targetPath)
+	if err != nil {
+		return errors.Wrap(err, "could not create local FS entry for "+targetPath)
+	}
+
+	// Set owner user and group from e
+	if le.Owner() != e.Owner() {
+		if err = os.Chown(targetPath, int(e.Owner().UserID), int(e.Owner().GroupID)); err != nil && !os.IsPermission(err) {
+			return errors.Wrap(err, "could not change owner/group for "+targetPath)
+		}
+	}
+
+	// Set file permissions from e
+	if (le.Mode() & modBits) != (e.Mode() & modBits) {
+		if err = os.Chmod(targetPath, e.Mode()&modBits); err != nil && !os.IsPermission(err) {
+			return errors.Wrap(err, "could not change permissions on "+targetPath)
+		}
+	}
+
+	// Set mod time from e
+	if !le.ModTime().Equal(e.ModTime()) {
+		// Note: Set atime to ModTime as well
+		if err = os.Chtimes(targetPath, e.ModTime(), e.ModTime()); err != nil && !os.IsPermission(err) {
+			return errors.Wrap(err, "could not change mod time on "+targetPath)
+		}
+	}
+
+	return nil
+}
+
+func copyDirectory(ctx context.Context, d fs.Directory, targetPath string) error {
+	if err := createDirectory(targetPath); err != nil {
+		return err
+	}
+
+	return copyDirectoryContent(ctx, d, targetPath)
+}
+
+func copyDirectoryContent(ctx context.Context, d fs.Directory, targetPath string) error {
+	entries, err := d.Readdir(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, e := range entries {
+		if err := copyEntry(ctx, e, filepath.Join(targetPath, e.Name())); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func createDirectory(path string) error {
+	switch stat, err := os.Stat(path); {
+	case os.IsNotExist(err):
+		return os.MkdirAll(path, 0700)
+	case err != nil:
+		return errors.Wrap(err, "failed to stat path "+path)
+	case stat.Mode().IsDir():
+		return errors.Errorf("directory already exists, not overwriting it: %q", path)
+	default:
+		return errors.Errorf("unable to create directory, %q already exists and it is not a directory", path)
+	}
+}
+
+func copyFileContent(ctx context.Context, targetPath string, f fs.File) error {
+	var out *os.File
+
+	switch _, err := os.Stat(targetPath); {
+	case os.IsNotExist(err):
+		if out, err = os.Create(targetPath); err != nil {
+			return errors.Wrap(err, "failed to create new file "+targetPath)
+		}
+		defer out.Close() //nolint:errcheck
+	case err == nil:
+		return errors.Errorf("unable to create %q, it already exists", targetPath)
+	default:
+		return errors.Wrap(err, "failed to stat "+targetPath)
+	}
+
+	r, err := f.Open(ctx)
+	if err != nil {
+		return errors.Wrap(err, "unable to open snapshot file for "+targetPath)
+	}
+	defer r.Close() //nolint:errcheck
+
+	if _, err = io.Copy(out, r); err != nil {
+		return errors.Wrapf(err, "unable to restore %q content", targetPath)
+	}
+
+	return out.Sync()
+}

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/pkg/profile v1.3.0
 	github.com/pkg/sftp v1.10.1
 	github.com/skratchdot/open-golang v0.0.0-20190402232053-79abb63cd66e
+	github.com/stretchr/testify v1.4.0
 	github.com/studio-b12/gowebdav v0.0.0-20190103184047-38f79aeaf1ac
 	github.com/zalando/go-keyring v0.0.0-20190715212148-76787ff3b3bd
 	golang.org/x/crypto v0.0.0-20190829043050-9756ffdc2472

--- a/go.sum
+++ b/go.sum
@@ -105,6 +105,7 @@ github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/studio-b12/gowebdav v0.0.0-20190103184047-38f79aeaf1ac h1:xQ9gCVzqb939vjhxuES4IXYe4AlHB4Q71/K06aazQmQ=
 github.com/studio-b12/gowebdav v0.0.0-20190103184047-38f79aeaf1ac/go.mod h1:gCcfDlA1Y7GqOaeEKw5l9dOGx1VLdc/HuQSlQAaZ30s=
@@ -224,6 +225,7 @@ gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLks
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/ini.v1 v1.42.0 h1:7N3gPTt50s8GuLortA00n8AqRTk75qOP98+mTPpgzRk=
 gopkg.in/ini.v1 v1.42.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/internal/fshasher/fshasher.go
+++ b/internal/fshasher/fshasher.go
@@ -1,0 +1,122 @@
+// Package fshasher computes a fingerprint for an FS tree for testing purposes
+package fshasher
+
+import (
+	"archive/tar"
+	"context"
+	"io"
+	"os"
+	"path"
+	"time"
+
+	"golang.org/x/crypto/blake2s"
+
+	"github.com/kopia/kopia/fs"
+	"github.com/kopia/kopia/internal/repologging"
+)
+
+var log = repologging.Logger("kopia/internal/fshasher")
+
+// Hash computes a recursive hash of e using the given hasher h
+func Hash(ctx context.Context, e fs.Entry) ([]byte, error) {
+	h, err := blake2s.New256(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	tw := tar.NewWriter(h)
+	defer tw.Close()
+
+	if err := write(ctx, tw, "", e); err != nil {
+		return nil, err
+	}
+
+	if err := tw.Flush(); err != nil {
+		return nil, err
+	}
+
+	return h.Sum(nil), nil
+}
+
+// nolint:interfacer
+func write(ctx context.Context, tw *tar.Writer, fullpath string, e fs.Entry) error {
+	h, err := header(ctx, fullpath, e)
+	if err != nil {
+		return err
+	}
+
+	log.Debug(e.Mode(), h.ModTime.Format(time.RFC3339), h.Size, h.Name)
+
+	if err := tw.WriteHeader(h); err != nil {
+		return err
+	}
+
+	switch e := e.(type) {
+	case fs.Directory:
+		return writeDirectory(ctx, tw, fullpath, e)
+	case fs.File:
+		return writeFile(ctx, tw, e)
+	default: // fs.Symlink or bare fs.Entry
+		return nil
+	}
+}
+
+func header(ctx context.Context, fullpath string, e os.FileInfo) (*tar.Header, error) {
+	var link string
+
+	if sl, ok := e.(fs.Symlink); ok {
+		l, err := sl.Readlink(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		link = l
+	}
+
+	h, err := tar.FileInfoHeader(e, link)
+	if err != nil {
+		return nil, err
+	}
+
+	h.Name = fullpath
+
+	// clear fields that may cause spurious differences
+	if e.IsDir() {
+		// reset times for directories given how ModTime is set in
+		// snapshot directories
+		h.ModTime = time.Time{}
+	}
+
+	h.ModTime = h.ModTime.UTC()
+	h.AccessTime = h.ModTime
+	h.ChangeTime = h.ModTime
+
+	return h, nil
+}
+
+func writeDirectory(ctx context.Context, tw *tar.Writer, fullpath string, d fs.Directory) error {
+	entries, err := d.Readdir(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, e := range entries {
+		if err := write(ctx, tw, path.Join(fullpath, e.Name()), e); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func writeFile(ctx context.Context, w io.Writer, f fs.File) error {
+	r, err := f.Open(ctx)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	_, err = io.Copy(w, r)
+
+	return err
+}

--- a/internal/fshasher/fshasher_test.go
+++ b/internal/fshasher/fshasher_test.go
@@ -1,0 +1,63 @@
+package fshasher
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/internal/mockfs"
+)
+
+// nolint:gocritic
+func TestHash(t *testing.T) {
+	const expectDifferentHashes = "Expected different hashes, got the same"
+
+	root := mockfs.NewDirectory()
+	root.AddFile("file1", []byte("foo-bar"), 0444)
+
+	d1 := root.AddDir("dir1", 0755)
+	d1.AddFile("d1-f1", []byte("d1-f1-content"), 0644)
+
+	ensure := require.New(t)
+	ctx := context.Background()
+	h1, err := Hash(ctx, root)
+	ensure.NoError(err)
+
+	d2 := root.AddDir("dir2", 0755)
+	d2.AddFile("d1-f1", []byte("d1-f1-content"), 0644)
+
+	h2, err := Hash(ctx, root)
+	ensure.NoError(err)
+	ensure.NotEqual(h1, h2, expectDifferentHashes)
+
+	hd1, err := Hash(ctx, d1)
+	ensure.NoError(err)
+
+	hd2, err := Hash(ctx, d2)
+	ensure.NoError(err)
+
+	ensure.Equal(hd1, hd2, "Expected same hashes, got the different ones")
+
+	// Add an entry to d2
+	d2.AddFile("f2", []byte("f2-content"), 0444)
+	hd2, err = Hash(ctx, d2)
+	ensure.NoError(err)
+	ensure.NotEqual(hd1, hd2, expectDifferentHashes)
+
+	// Test different permission attributes for the top directory
+	// d3 is the same as d1, but with different permissions
+	d3 := root.AddDir("dir3", 0700)
+	d3.AddFile("d1-f1", []byte("d1-f1-content"), 0644)
+	hd3, err := Hash(ctx, d3)
+	ensure.NoError(err)
+	ensure.NotEqual(hd3, hd1, expectDifferentHashes)
+
+	// Test different permission attributes for file
+	// d4 is the same as d2, but with different permissions in d1-f1
+	d4 := root.AddDir("dir4", 0700)
+	d4.AddFile("d1-f1", []byte("d1-f1-content"), 0644)
+	hd4, err := Hash(ctx, d4)
+	ensure.NoError(err)
+	ensure.NotEqual(hd4, hd1, expectDifferentHashes)
+}

--- a/snapshot/snapshotfs/restore.go
+++ b/snapshot/snapshotfs/restore.go
@@ -1,0 +1,14 @@
+package snapshotfs
+
+import (
+	"context"
+
+	"github.com/kopia/kopia/fs/localfs"
+	"github.com/kopia/kopia/repo"
+	"github.com/kopia/kopia/repo/object"
+)
+
+// Restore walks a snapshot root with given object ID and restores it to the local filesystem
+func Restore(ctx context.Context, rep *repo.Repository, targetPath string, oid object.ID) error {
+	return localfs.Copy(ctx, targetPath, DirectoryEntry(rep, oid, nil))
+}


### PR DESCRIPTION
### Change Overview
```
bash-4.4# kopia restore --help
usage: kopia restore <root-id> <target-path>

Commands to restore snapshots.

Flags:
      --help                  Show context-sensitive help (also try --help-long and --help-man).
      --help-full             Show help for all commands, including hidden
      --trace-object-manager  Enables tracing of object manager operations.
      --trace-localfs         Enables tracing of local filesystem operations
      --config-file="/Users/pdevaraj/Library/Application Support/kopia/repository.config"
                              Specify the config file to use.
  -p, --password=PASSWORD     Repository password.
      --use-keychain          Use macOS Keychain for storing repository password.
      --log-file=LOG-FILE     Log file name.
      --log-dir="/Users/pdevaraj/Library/Logs/kopia"
                              Directory where log files should be written.
      --log-level=info        Console log level
      --file-log-level=info   File log level
      --version               Show application version.

Args:
  <root-id>      Snapshot Root ID from which to restore.
  <target-path>  Path to which the snapshot must be restored.
```
Walks through all the entries for the given root ID and restores all the files/directories recursively.

Yet to address: symlinks

### Pull request type

- [x] 🌻 Feature

### Test Plan

🚀 Manually backed up and restored a directory structure successfully.
Added checks to prevent override of existing files.

```
pdevaraj @ ~/Work/Kasten/kopia - [restore_test] $ ./kopia restore ke01a036be699f043a5677ed7c8858af8 ./tmp
pdevaraj @ ~/Work/Kasten/kopia - [restore_cmd] $ kopia restore ke01a036be699f043a5677ed7c8858af8 ./tmp
kopia: error: unable to create a new file, tmp/d1/f4.txt already exists, try --help
```