### PR TITLE
[124] Add optional flags to override hostname and username

### DIFF
--- a/cli/command_policy_edit.go
+++ b/cli/command_policy_edit.go
@@ -26,11 +26,11 @@ const policyEditHelpText = `
 
 const policyEditRetentionHelpText = `  # Retention for snapshots of this directory. Options include:
   #   "keepLatest": number
-  #   "keepDaily": number 
-  #   "keepHourly": number 
-  #   "keepWeekly": number     
-  #   "keepMonthly": number    
-  #   "keepAnnual": number     
+  #   "keepDaily": number
+  #   "keepHourly": number
+  #   "keepWeekly": number
+  #   "keepMonthly": number
+  #   "keepAnnual": number
 `
 
 const policyEditFilesHelpText = `
@@ -45,7 +45,7 @@ const policyEditFilesHelpText = `
 const policyEditSchedulingHelpText = `
   # Snapshot scheduling options. Options include:
   #   "intervalSeconds": number /* 86400-day, 3600-hour, 60-minute */
-  #   "timesOfDay": [{"hour":H,"min":M},{"hour":H,"min":M}] 
+  #   "timesOfDay": [{"hour":H,"min":M},{"hour":H,"min":M}]
 `
 
 var (
@@ -55,6 +55,7 @@ var (
 )
 
 func init() {
+	addUserAndHostFlags(policyEditCommand)
 	policyEditCommand.Action(repositoryAction(editPolicy))
 }
 

--- a/cli/command_policy_remove.go
+++ b/cli/command_policy_remove.go
@@ -14,6 +14,7 @@ var (
 )
 
 func init() {
+	addUserAndHostFlags(policyRemoveCommand)
 	policyRemoveCommand.Action(repositoryAction(removePolicy))
 }
 

--- a/cli/command_policy_set.go
+++ b/cli/command_policy_set.go
@@ -50,6 +50,7 @@ const (
 )
 
 func init() {
+	addUserAndHostFlags(policySetCommand)
 	policySetCommand.Action(repositoryAction(setPolicy))
 }
 

--- a/cli/command_policy_show.go
+++ b/cli/command_policy_show.go
@@ -19,6 +19,7 @@ var (
 )
 
 func init() {
+	addUserAndHostFlags(policyShowCommand)
 	policyShowCommand.Action(repositoryAction(showPolicy))
 }
 

--- a/cli/command_server_start.go
+++ b/cli/command_server_start.go
@@ -23,6 +23,7 @@ var (
 )
 
 func init() {
+	addUserAndHostFlags(serverStartCommand)
 	serverStartCommand.Action(repositoryAction(runServer))
 }
 

--- a/cli/command_snapshot_create.go
+++ b/cli/command_snapshot_create.go
@@ -181,10 +181,10 @@ func getLocalBackupPaths(ctx context.Context, rep *repo.Repository) ([]string, e
 }
 
 func getUserName() string {
-	if len(overrideUserName) > 0 {
-		return overrideUserName
-	}
+	return userName
+}
 
+func getDefaultUserName() string {
 	currentUser, err := user.Current()
 	if err != nil {
 		log.Warningf("Cannot determine current user: %s", err)
@@ -203,10 +203,10 @@ func getUserName() string {
 }
 
 func getHostName() string {
-	if len(overrideHostName) > 0 {
-		return overrideHostName
-	}
+	return hostName
+}
 
+func getDefaultHostName() string {
 	hostname, err := os.Hostname()
 	if err != nil {
 		log.Warningf("Unable to determine hostname: %s", err)
@@ -220,6 +220,6 @@ func getHostName() string {
 }
 
 func init() {
-	setupOverrideOptions(snapshotCreateCommand)
+	addUserAndHostFlags(snapshotCreateCommand)
 	snapshotCreateCommand.Action(repositoryAction(runBackupCommand))
 }

--- a/cli/command_snapshot_create.go
+++ b/cli/command_snapshot_create.go
@@ -181,6 +181,10 @@ func getLocalBackupPaths(ctx context.Context, rep *repo.Repository) ([]string, e
 }
 
 func getUserName() string {
+	if len(overrideUserName) > 0 {
+		return overrideUserName
+	}
+
 	currentUser, err := user.Current()
 	if err != nil {
 		log.Warningf("Cannot determine current user: %s", err)
@@ -199,6 +203,10 @@ func getUserName() string {
 }
 
 func getHostName() string {
+	if len(overrideHostName) > 0 {
+		return overrideHostName
+	}
+
 	hostname, err := os.Hostname()
 	if err != nil {
 		log.Warningf("Unable to determine hostname: %s", err)
@@ -212,5 +220,6 @@ func getHostName() string {
 }
 
 func init() {
+	setupOverrideOptions(snapshotCreateCommand)
 	snapshotCreateCommand.Action(repositoryAction(runBackupCommand))
 }

--- a/cli/command_snapshot_estimate.go
+++ b/cli/command_snapshot_estimate.go
@@ -156,5 +156,6 @@ func estimate(ctx context.Context, relativePath string, entry fs.Entry, stats *s
 }
 
 func init() {
+	setupOverrideOptions(snapshotEstimate)
 	snapshotEstimate.Action(repositoryAction(runSnapshotEstimateCommand))
 }

--- a/cli/command_snapshot_estimate.go
+++ b/cli/command_snapshot_estimate.go
@@ -156,6 +156,6 @@ func estimate(ctx context.Context, relativePath string, entry fs.Entry, stats *s
 }
 
 func init() {
-	setupOverrideOptions(snapshotEstimate)
+	addUserAndHostFlags(snapshotEstimate)
 	snapshotEstimate.Action(repositoryAction(runSnapshotEstimateCommand))
 }

--- a/cli/command_snapshot_expire.go
+++ b/cli/command_snapshot_expire.go
@@ -68,6 +68,6 @@ func runExpireCommand(ctx context.Context, rep *repo.Repository) error {
 }
 
 func init() {
-	setupOverrideOptions(snapshotExpireCommand)
+	addUserAndHostFlags(snapshotExpireCommand)
 	snapshotExpireCommand.Action(repositoryAction(runExpireCommand))
 }

--- a/cli/command_snapshot_expire.go
+++ b/cli/command_snapshot_expire.go
@@ -68,5 +68,6 @@ func runExpireCommand(ctx context.Context, rep *repo.Repository) error {
 }
 
 func init() {
+	setupOverrideOptions(snapshotExpireCommand)
 	snapshotExpireCommand.Action(repositoryAction(runExpireCommand))
 }

--- a/cli/command_snapshot_list.go
+++ b/cli/command_snapshot_list.go
@@ -262,5 +262,6 @@ func deltaBytes(b int64) string {
 }
 
 func init() {
+	setupOverrideOptions(snapshotListCommand)
 	snapshotListCommand.Action(repositoryAction(runSnapshotsCommand))
 }

--- a/cli/command_snapshot_list.go
+++ b/cli/command_snapshot_list.go
@@ -262,6 +262,6 @@ func deltaBytes(b int64) string {
 }
 
 func init() {
-	setupOverrideOptions(snapshotListCommand)
+	addUserAndHostFlags(snapshotListCommand)
 	snapshotListCommand.Action(repositoryAction(runSnapshotsCommand))
 }

--- a/cli/command_snapshot_migrate.go
+++ b/cli/command_snapshot_migrate.go
@@ -209,5 +209,6 @@ func getSourcesToMigrate(ctx context.Context, rep *repo.Repository) ([]snapshot.
 }
 
 func init() {
+	setupOverrideOptions(migrateCommand)
 	migrateCommand.Action(repositoryAction(runMigrateCommand))
 }

--- a/cli/command_snapshot_migrate.go
+++ b/cli/command_snapshot_migrate.go
@@ -209,6 +209,6 @@ func getSourcesToMigrate(ctx context.Context, rep *repo.Repository) ([]snapshot.
 }
 
 func init() {
-	setupOverrideOptions(migrateCommand)
+	addUserAndHostFlags(migrateCommand)
 	migrateCommand.Action(repositoryAction(runMigrateCommand))
 }

--- a/cli/command_snapshot_verify.go
+++ b/cli/command_snapshot_verify.go
@@ -271,5 +271,6 @@ func loadSourceManifests(ctx context.Context, rep *repo.Repository, sources []st
 }
 
 func init() {
+	setupOverrideOptions(verifyCommand)
 	verifyCommand.Action(repositoryAction(runVerifyCommand))
 }

--- a/cli/command_snapshot_verify.go
+++ b/cli/command_snapshot_verify.go
@@ -271,6 +271,6 @@ func loadSourceManifests(ctx context.Context, rep *repo.Repository, sources []st
 }
 
 func init() {
-	setupOverrideOptions(verifyCommand)
+	addUserAndHostFlags(verifyCommand)
 	verifyCommand.Action(repositoryAction(runVerifyCommand))
 }

--- a/cli/snapshot_utils.go
+++ b/cli/snapshot_utils.go
@@ -1,0 +1,15 @@
+package cli
+
+import (
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+var (
+	overrideHostName string
+	overrideUserName string
+)
+
+func setupOverrideOptions(cmd *kingpin.CmdClause) {
+	cmd.Flag("override-hostname", "Override system hostname.").StringVar(&overrideHostName)
+	cmd.Flag("override-username", "Override system username.").StringVar(&overrideUserName)
+}

--- a/cli/snapshot_utils.go
+++ b/cli/snapshot_utils.go
@@ -5,11 +5,11 @@ import (
 )
 
 var (
-	overrideHostName string
-	overrideUserName string
+	hostName = getDefaultHostName()
+	userName = getDefaultUserName()
 )
 
-func setupOverrideOptions(cmd *kingpin.CmdClause) {
-	cmd.Flag("override-hostname", "Override system hostname.").StringVar(&overrideHostName)
-	cmd.Flag("override-username", "Override system username.").StringVar(&overrideUserName)
+func addUserAndHostFlags(cmd *kingpin.CmdClause) {
+	cmd.Flag("hostname", "Override default hostname.").StringVar(&hostName)
+	cmd.Flag("username", "Override default username.").StringVar(&userName)
 }

--- a/tests/end_to_end_test/end_to_end_test.go
+++ b/tests/end_to_end_test/end_to_end_test.go
@@ -157,8 +157,8 @@ func TestEndToEnd(t *testing.T) {
 
 	dir3 := filepath.Join(e.dataDir, "dir3")
 	createDirectory(t, dir3, 3)
-	e.runAndExpectSuccess(t, "snapshot", "create", "--hostname", "bar", "--username", "foo", dir3)
-	e.runAndExpectSuccess(t, "snapshot", "list", "--hostname", "bar", "--username", "foo", dir3)
+	e.runAndExpectSuccess(t, "snapshot", "create", "--override-hostname", "bar", "--override-username", "foo", dir3)
+	e.runAndExpectSuccess(t, "snapshot", "list", "--override-hostname", "bar", "--override-username", "foo", dir3)
 
 	sources := listSnapshotsAndExpectSuccess(t, e)
 	if got, want := len(sources), 3; got != want {

--- a/tests/end_to_end_test/end_to_end_test.go
+++ b/tests/end_to_end_test/end_to_end_test.go
@@ -157,8 +157,8 @@ func TestEndToEnd(t *testing.T) {
 
 	dir3 := filepath.Join(e.dataDir, "dir3")
 	createDirectory(t, dir3, 3)
-	e.runAndExpectSuccess(t, "snapshot", "create", "--override-hostname", "bar", "--override-username", "foo", dir3)
-	e.runAndExpectSuccess(t, "snapshot", "list", "--override-hostname", "bar", "--override-username", "foo", dir3)
+	e.runAndExpectSuccess(t, "snapshot", "create", "--hostname", "bar", "--username", "foo", dir3)
+	e.runAndExpectSuccess(t, "snapshot", "list", "--hostname", "bar", "--username", "foo", dir3)
 
 	sources := listSnapshotsAndExpectSuccess(t, e)
 	if got, want := len(sources), 3; got != want {

--- a/tests/end_to_end_test/end_to_end_test.go
+++ b/tests/end_to_end_test/end_to_end_test.go
@@ -154,13 +154,19 @@ func TestEndToEnd(t *testing.T) {
 	createDirectory(t, dir2, 3)
 	e.runAndExpectSuccess(t, "snapshot", "create", dir2)
 	e.runAndExpectSuccess(t, "snapshot", "create", dir2)
+
+	dir3 := filepath.Join(e.dataDir, "dir3")
+	createDirectory(t, dir3, 3)
+	e.runAndExpectSuccess(t, "snapshot", "create", "--hostname", "bar", "--username", "foo", dir3)
+	e.runAndExpectSuccess(t, "snapshot", "list", "--hostname", "bar", "--username", "foo", dir3)
+
 	sources := listSnapshotsAndExpectSuccess(t, e)
 	if got, want := len(sources), 3; got != want {
 		t.Errorf("unexpected number of sources: %v, want %v in %#v", got, want, sources)
 	}
 
-	// expect 5 blobs, each snapshot creation adds one index blob
-	e.runAndVerifyOutputLineCount(t, 6, "index", "ls")
+	// expect 7 blobs, each snapshot creation adds one index blob
+	e.runAndVerifyOutputLineCount(t, 7, "index", "ls")
 	e.runAndExpectSuccess(t, "index", "optimize")
 	e.runAndVerifyOutputLineCount(t, 1, "index", "ls")
 


### PR DESCRIPTION
## Change Overview

- Add optional flags to override hostname and username
- Add the flags to `snapshot`, `policy` and `server start` commands
- Add a test case in the E2E tests to create and list snapshots with overridden hostname and username


## Pull Request Type

- [x] 🌻 Feature

## Issues

- kopia/kopia#124

## Test Plan

- [x] Manual
- [x] E2E