### PR TITLE
Dedicated snapshot delete command to delete by snap ID

### DIFF
--- a/cli/command_snapshot_delete.go
+++ b/cli/command_snapshot_delete.go
@@ -11,12 +11,12 @@ import (
 var (
 	snapshotDeleteCommand        = snapshotCommands.Command("delete", "Explicitly delete a snapshot by providing a snapshot ID.")
 	snapshotDeleteID             = snapshotDeleteCommand.Arg("id", "Snapshot ID to be deleted").Required().String()
-	snapshotDeleteHostName       = snapshotDeleteCommand.Flag("host", "Snapshot ID to be deleted").String()
-	snapshotDeleteUserName       = snapshotDeleteCommand.Flag("user", "Snapshot ID to be deleted").String()
-	snapshotDeletePath           = snapshotDeleteCommand.Flag("path", "Delete snapshot for a given path only").String()
-	snapshotDeleteIgnoreHostName = snapshotDeleteCommand.Flag("unsafe-ignore-host", "Snapshot ID to be deleted").Bool()
-	snapshotDeleteIgnoreUserName = snapshotDeleteCommand.Flag("unsafe-ignore-user", "Snapshot ID to be deleted").Bool()
-	snapshotDeleteIgnorePath     = snapshotDeleteCommand.Flag("unsafe-ignore-path", "Snapshot ID to be deleted").Bool()
+	snapshotDeleteHostName       = snapshotDeleteCommand.Flag("hostname", "Specify the host name of the snapshot to be deleted").String()
+	snapshotDeleteUserName       = snapshotDeleteCommand.Flag("username", "Specify the user name of the snapshot to be deleted").String()
+	snapshotDeletePath           = snapshotDeleteCommand.Flag("path", "Specify the path of the snapshot to be deleted").String()
+	snapshotDeleteIgnoreHostName = snapshotDeleteCommand.Flag("unsafe-ignore-host", "Override the requirement to specify a host name for the delete to succeed").Bool()
+	snapshotDeleteIgnoreUserName = snapshotDeleteCommand.Flag("unsafe-ignore-user", "Override the requirement to specify a user name for the delete to succeed").Bool()
+	snapshotDeleteIgnorePath     = snapshotDeleteCommand.Flag("unsafe-ignore-path", "Override the requirement to specify a path for the delete to succeed").Bool()
 )
 
 func runDeleteCommand(ctx context.Context, rep *repo.Repository) error {
@@ -53,6 +53,5 @@ func runDeleteCommand(ctx context.Context, rep *repo.Repository) error {
 }
 
 func init() {
-	addUserAndHostFlags(snapshotDeleteCommand)
 	snapshotDeleteCommand.Action(repositoryAction(runDeleteCommand))
 }

--- a/cli/command_snapshot_delete.go
+++ b/cli/command_snapshot_delete.go
@@ -9,24 +9,14 @@ import (
 )
 
 var (
-	snapshotDeleteCommand        = snapshotCommands.Command("delete", "Explicitly delete a snapshot by providing a snapshot ID.")
-	snapshotDeleteID             = snapshotDeleteCommand.Arg("id", "Snapshot ID to be deleted").Required().String()
-	snapshotDeleteHostName       = snapshotDeleteCommand.Flag("hostname", "Specify the host name of the snapshot to be deleted").String()
-	snapshotDeleteUserName       = snapshotDeleteCommand.Flag("username", "Specify the user name of the snapshot to be deleted").String()
-	snapshotDeletePath           = snapshotDeleteCommand.Flag("path", "Specify the path of the snapshot to be deleted").String()
-	snapshotDeleteIgnoreHostName = snapshotDeleteCommand.Flag("unsafe-ignore-host", "Override the requirement to specify a host name for the delete to succeed").Bool()
-	snapshotDeleteIgnoreUserName = snapshotDeleteCommand.Flag("unsafe-ignore-user", "Override the requirement to specify a user name for the delete to succeed").Bool()
-	snapshotDeleteIgnorePath     = snapshotDeleteCommand.Flag("unsafe-ignore-path", "Override the requirement to specify a path for the delete to succeed").Bool()
+	snapshotDeleteCommand      = snapshotCommands.Command("delete", "Explicitly delete a snapshot by providing a snapshot ID.")
+	snapshotDeleteID           = snapshotDeleteCommand.Arg("id", "Snapshot ID to be deleted").Required().String()
+	snapshotDeletePath         = snapshotDeleteCommand.Flag("path", "Specify the path of the snapshot to be deleted").String()
+	snapshotDeleteIgnoreSource = snapshotDeleteCommand.Flag("unsafe-ignore-source", "Override the requirement to specify source info for the delete to succeed").Bool()
 )
 
 func runDeleteCommand(ctx context.Context, rep *repo.Repository) error {
-	if !*snapshotDeleteIgnoreHostName && *snapshotDeleteHostName == "" {
-		return errors.New("host name is required")
-	}
-	if !*snapshotDeleteIgnoreUserName && *snapshotDeleteUserName == "" {
-		return errors.New("user name is required")
-	}
-	if !*snapshotDeleteIgnorePath && *snapshotDeletePath == "" {
+	if !*snapshotDeleteIgnoreSource && *snapshotDeletePath == "" {
 		return errors.New("path is required")
 	}
 
@@ -39,19 +29,22 @@ func runDeleteCommand(ctx context.Context, rep *repo.Repository) error {
 	if labels["type"] != "snapshot" {
 		return errors.New("snapshot ID provided did not reference a snapshot")
 	}
-	if labels["hostname"] != *snapshotDeleteHostName && !*snapshotDeleteIgnoreHostName {
-		return errors.New("host name does not match for deleting requested snapshot ID")
-	}
-	if labels["username"] != *snapshotDeleteUserName && !*snapshotDeleteIgnoreUserName {
-		return errors.New("user name does not match for deleting requested snapshot ID")
-	}
-	if labels["path"] != *snapshotDeletePath && !*snapshotDeleteIgnorePath {
-		return errors.New("path does not match for deleting requested snapshot ID")
+	if !*snapshotDeleteIgnoreSource {
+		if labels["hostname"] != getHostName() {
+			return errors.New("host name does not match for deleting requested snapshot ID")
+		}
+		if labels["username"] != getUserName() {
+			return errors.New("user name does not match for deleting requested snapshot ID")
+		}
+		if labels["path"] != *snapshotDeletePath {
+			return errors.New("path does not match for deleting requested snapshot ID")
+		}
 	}
 
 	return rep.Manifests.Delete(ctx, manifestID)
 }
 
 func init() {
+	addUserAndHostFlags(snapshotDeleteCommand)
 	snapshotDeleteCommand.Action(repositoryAction(runDeleteCommand))
 }

--- a/cli/command_snapshot_delete.go
+++ b/cli/command_snapshot_delete.go
@@ -27,7 +27,7 @@ func runDeleteCommand(ctx context.Context, rep *repo.Repository) error {
 	}
 	labels := manifestMeta.Labels
 	if labels["type"] != "snapshot" {
-		return errors.New("snapshot ID provided did not reference a snapshot")
+		return errors.Errorf("snapshot ID provided (%v) did not reference a snapshot", manifestID)
 	}
 	if !*snapshotDeleteIgnoreSource {
 		if labels["hostname"] != getHostName() {

--- a/cli/command_snapshot_delete.go
+++ b/cli/command_snapshot_delete.go
@@ -1,0 +1,23 @@
+package cli
+
+import (
+	"context"
+
+	"github.com/kopia/kopia/repo"
+	"github.com/kopia/kopia/repo/manifest"
+)
+
+var (
+	snapshotDeleteCommand = snapshotCommands.Command("delete", "Explicitly delete a snapshot by providing a snapshot ID.")
+
+	snapshotDeleteID = snapshotDeleteCommand.Arg("id", "Snapshot ID to be deleted").String()
+)
+
+func runDeleteCommand(ctx context.Context, rep *repo.Repository) error {
+	return rep.Manifests.Delete(ctx, manifest.ID(*snapshotDeleteID))
+}
+
+func init() {
+	addUserAndHostFlags(snapshotDeleteCommand)
+	snapshotDeleteCommand.Action(repositoryAction(runDeleteCommand))
+}

--- a/cli/command_snapshot_delete.go
+++ b/cli/command_snapshot_delete.go
@@ -5,16 +5,51 @@ import (
 
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/manifest"
+	"github.com/pkg/errors"
 )
 
 var (
-	snapshotDeleteCommand = snapshotCommands.Command("delete", "Explicitly delete a snapshot by providing a snapshot ID.")
-
-	snapshotDeleteID = snapshotDeleteCommand.Arg("id", "Snapshot ID to be deleted").String()
+	snapshotDeleteCommand        = snapshotCommands.Command("delete", "Explicitly delete a snapshot by providing a snapshot ID.")
+	snapshotDeleteID             = snapshotDeleteCommand.Arg("id", "Snapshot ID to be deleted").Required().String()
+	snapshotDeleteHostName       = snapshotDeleteCommand.Flag("host", "Snapshot ID to be deleted").String()
+	snapshotDeleteUserName       = snapshotDeleteCommand.Flag("user", "Snapshot ID to be deleted").String()
+	snapshotDeletePath           = snapshotDeleteCommand.Flag("path", "Delete snapshot for a given path only").String()
+	snapshotDeleteIgnoreHostName = snapshotDeleteCommand.Flag("unsafe-ignore-host", "Snapshot ID to be deleted").Bool()
+	snapshotDeleteIgnoreUserName = snapshotDeleteCommand.Flag("unsafe-ignore-user", "Snapshot ID to be deleted").Bool()
+	snapshotDeleteIgnorePath     = snapshotDeleteCommand.Flag("unsafe-ignore-path", "Snapshot ID to be deleted").Bool()
 )
 
 func runDeleteCommand(ctx context.Context, rep *repo.Repository) error {
-	return rep.Manifests.Delete(ctx, manifest.ID(*snapshotDeleteID))
+	if !*snapshotDeleteIgnoreHostName && *snapshotDeleteHostName == "" {
+		return errors.New("host name is required")
+	}
+	if !*snapshotDeleteIgnoreUserName && *snapshotDeleteUserName == "" {
+		return errors.New("user name is required")
+	}
+	if !*snapshotDeleteIgnorePath && *snapshotDeletePath == "" {
+		return errors.New("path is required")
+	}
+
+	manifestID := manifest.ID(*snapshotDeleteID)
+	manifestMeta, err := rep.Manifests.GetMetadata(ctx, manifestID)
+	if err != nil {
+		return err
+	}
+	labels := manifestMeta.Labels
+	if labels["type"] != "snapshot" {
+		return errors.New("snapshot ID provided did not reference a snapshot")
+	}
+	if labels["hostname"] != *snapshotDeleteHostName && !*snapshotDeleteIgnoreHostName {
+		return errors.New("host name does not match for deleting requested snapshot ID")
+	}
+	if labels["username"] != *snapshotDeleteUserName && !*snapshotDeleteIgnoreUserName {
+		return errors.New("user name does not match for deleting requested snapshot ID")
+	}
+	if labels["path"] != *snapshotDeletePath && !*snapshotDeleteIgnorePath {
+		return errors.New("path does not match for deleting requested snapshot ID")
+	}
+
+	return rep.Manifests.Delete(ctx, manifestID)
 }
 
 func init() {

--- a/tests/end_to_end_test/end_to_end_test.go
+++ b/tests/end_to_end_test/end_to_end_test.go
@@ -232,65 +232,6 @@ func TestEndToEnd(t *testing.T) {
 	})
 }
 
-func TestSnapshotGC(t *testing.T) {
-	e := newTestEnv(t)
-	defer e.cleanup(t)
-	defer e.runAndExpectSuccess(t, "repo", "disconnect")
-
-	e.runAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.repoDir)
-
-	expectedContentCount := len(e.runAndExpectSuccess(t, "content", "list"))
-
-	dataDir := filepath.Join(e.dataDir, "dir1")
-	assertNoError(t, os.MkdirAll(dataDir, 0777))
-	assertNoError(t, ioutil.WriteFile(filepath.Join(dataDir, "some-file1"), []byte(`
-hello world
-how are you
-`), 0600))
-
-	// take a snapshot of a directory with 1 file
-	e.runAndExpectSuccess(t, "snap", "create", dataDir)
-
-	// data block + directory block + manifest block
-	expectedContentCount += 3
-	e.runAndVerifyOutputLineCount(t, expectedContentCount, "content", "list")
-
-	// now delete all manifests, making the content unreachable
-	for _, line := range e.runAndExpectSuccess(t, "snap", "list", "-m") {
-		p := strings.Index(line, "manifest:")
-		if p >= 0 {
-			manifestID := strings.TrimPrefix(strings.Split(line[p:], " ")[0], "manifest:")
-			t.Logf("manifestID: %v", manifestID)
-			e.runAndExpectSuccess(t, "manifest", "rm", manifestID)
-		}
-	}
-
-	// deletion of manifests creates a new manifest
-	expectedContentCount++
-
-	// run verification
-	e.runAndExpectSuccess(t, "snapshot", "verify", "--all-sources")
-
-	// garbage-collect in dry run mode
-	e.runAndExpectSuccess(t, "snapshot", "gc")
-
-	// data block + directory block + manifest block + manifest block from manifest deletion
-	e.runAndVerifyOutputLineCount(t, expectedContentCount, "content", "list")
-
-	// garbage-collect for real, but contents are too recent so won't be deleted
-	e.runAndExpectSuccess(t, "snapshot", "gc", "--delete")
-
-	// data block + directory block + manifest block + manifest block from manifest deletion
-	e.runAndVerifyOutputLineCount(t, expectedContentCount, "content", "list")
-
-	// garbage-collect for real, this time without age limit
-	e.runAndExpectSuccess(t, "snapshot", "gc", "--delete", "--min-age", "0s")
-
-	// two contents are deleted
-	expectedContentCount -= 2
-	e.runAndVerifyOutputLineCount(t, expectedContentCount, "content", "list")
-}
-
 type deleteArgMaker func(manifestID string, source sourceInfo) []string
 
 func TestSnapshotDelete(t *testing.T) {

--- a/tests/end_to_end_test/end_to_end_test.go
+++ b/tests/end_to_end_test/end_to_end_test.go
@@ -523,6 +523,29 @@ how are you
 	}
 }
 
+func TestSnapshotDeleteTypeCheck(t *testing.T) {
+	e := newTestEnv(t)
+	defer e.cleanup(t)
+	defer e.runAndExpectSuccess(t, "repo", "disconnect")
+
+	e.runAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.repoDir)
+
+	lines := e.runAndExpectSuccess(t, "manifest", "ls")
+	if len(lines) != 1 {
+		t.Fatalf("Expected 1 line global policy output for manifest ls")
+	}
+	line := lines[0]
+	fields := strings.Fields(line)
+	manifestID := fields[0]
+	typeField := fields[5]
+	typeVal := strings.TrimPrefix(typeField, "type:")
+	if typeVal != "policy" {
+		t.Fatalf("Expected global policy manifest on a fresh repo")
+	}
+
+	e.runAndExpectFailure(t, "snapshot", "delete", manifestID, "--unsafe-ignore-source")
+}
+
 func TestSnapshotDeleteRestore(t *testing.T) {
 	e := newTestEnv(t)
 	defer e.cleanup(t)

--- a/tests/end_to_end_test/end_to_end_test.go
+++ b/tests/end_to_end_test/end_to_end_test.go
@@ -161,8 +161,8 @@ func TestEndToEnd(t *testing.T) {
 
 	dir3 := filepath.Join(e.dataDir, "dir3")
 	createDirectory(t, dir3, 3)
-	e.runAndExpectSuccess(t, "snapshot", "create", "--hostnamename", "bar", "--usernamename", "foo", dir3)
-	e.runAndExpectSuccess(t, "snapshot", "list", "--hostnamename", "bar", "--usernamename", "foo", dir3)
+	e.runAndExpectSuccess(t, "snapshot", "create", "--hostname", "bar", "--username", "foo", dir3)
+	e.runAndExpectSuccess(t, "snapshot", "list", "--hostname", "bar", "--username", "foo", dir3)
 
 	sources := listSnapshotsAndExpectSuccess(t, e)
 	if got, want := len(sources), 3; got != want {

--- a/tests/end_to_end_test/end_to_end_test.go
+++ b/tests/end_to_end_test/end_to_end_test.go
@@ -269,6 +269,18 @@ func TestSnapshotDelete(t *testing.T) {
 		},
 		{
 			func(manifestID string, source sourceInfo) []string {
+				return []string{"snapshot", "delete"}
+			},
+			expectFail,
+		},
+		{
+			func(manifestID string, source sourceInfo) []string {
+				return []string{"snapshot", "delete", "some-garbage-manifestID"}
+			},
+			expectFail,
+		},
+		{
+			func(manifestID string, source sourceInfo) []string {
 				return []string{"snapshot", "delete", manifestID,
 					"--hostname", "some-wrong-host",
 					"--username", source.user,

--- a/tests/end_to_end_test/end_to_end_test.go
+++ b/tests/end_to_end_test/end_to_end_test.go
@@ -232,6 +232,65 @@ func TestEndToEnd(t *testing.T) {
 	})
 }
 
+func TestSnapshotGC(t *testing.T) {
+	e := newTestEnv(t)
+	defer e.cleanup(t)
+	defer e.runAndExpectSuccess(t, "repo", "disconnect")
+
+	e.runAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.repoDir)
+
+	expectedContentCount := len(e.runAndExpectSuccess(t, "content", "list"))
+
+	dataDir := filepath.Join(e.dataDir, "dir1")
+	assertNoError(t, os.MkdirAll(dataDir, 0777))
+	assertNoError(t, ioutil.WriteFile(filepath.Join(dataDir, "some-file1"), []byte(`
+hello world
+how are you
+`), 0600))
+
+	// take a snapshot of a directory with 1 file
+	e.runAndExpectSuccess(t, "snap", "create", dataDir)
+
+	// data block + directory block + manifest block
+	expectedContentCount += 3
+	e.runAndVerifyOutputLineCount(t, expectedContentCount, "content", "list")
+
+	// now delete all manifests, making the content unreachable
+	for _, line := range e.runAndExpectSuccess(t, "snap", "list", "-m") {
+		p := strings.Index(line, "manifest:")
+		if p >= 0 {
+			manifestID := strings.TrimPrefix(strings.Split(line[p:], " ")[0], "manifest:")
+			t.Logf("manifestID: %v", manifestID)
+			e.runAndExpectSuccess(t, "manifest", "rm", manifestID)
+		}
+	}
+
+	// deletion of manifests creates a new manifest
+	expectedContentCount++
+
+	// run verification
+	e.runAndExpectSuccess(t, "snapshot", "verify", "--all-sources")
+
+	// garbage-collect in dry run mode
+	e.runAndExpectSuccess(t, "snapshot", "gc")
+
+	// data block + directory block + manifest block + manifest block from manifest deletion
+	e.runAndVerifyOutputLineCount(t, expectedContentCount, "content", "list")
+
+	// garbage-collect for real, but contents are too recent so won't be deleted
+	e.runAndExpectSuccess(t, "snapshot", "gc", "--delete")
+
+	// data block + directory block + manifest block + manifest block from manifest deletion
+	e.runAndVerifyOutputLineCount(t, expectedContentCount, "content", "list")
+
+	// garbage-collect for real, this time without age limit
+	e.runAndExpectSuccess(t, "snapshot", "gc", "--delete", "--min-age", "0s")
+
+	// two contents are deleted
+	expectedContentCount -= 2
+	e.runAndVerifyOutputLineCount(t, expectedContentCount, "content", "list")
+}
+
 type deleteArgMaker func(manifestID string, source sourceInfo) []string
 
 func TestSnapshotDelete(t *testing.T) {
@@ -421,8 +480,6 @@ func testSnapshotDelete(t *testing.T, argMaker deleteArgMaker, expectDeleteSucce
 
 	e.runAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.repoDir)
 
-	expectedContentCount := len(e.runAndExpectSuccess(t, "content", "list"))
-
 	dataDir := filepath.Join(e.dataDir, "dir1")
 	assertNoError(t, os.MkdirAll(dataDir, 0777))
 	assertNoError(t, ioutil.WriteFile(filepath.Join(dataDir, "some-file1"), []byte(`
@@ -432,10 +489,6 @@ how are you
 
 	// take a snapshot of a directory with 1 file
 	e.runAndExpectSuccess(t, "snap", "create", dataDir)
-
-	// data block + directory block + manifest block
-	expectedContentCount += 3
-	e.runAndVerifyOutputLineCount(t, expectedContentCount, "content", "list")
 
 	// now delete all manifests, making the content unreachable
 	si := listSnapshotsAndExpectSuccess(t, e, dataDir)
@@ -451,35 +504,6 @@ how are you
 			}
 		}
 	}
-
-	// deletion of manifests creates a new manifest
-	if expectDeleteSucceeds {
-		expectedContentCount++
-
-		// run verification
-		e.runAndExpectSuccess(t, "snapshot", "verify", "--all-sources")
-	}
-
-	// garbage-collect in dry run mode
-	e.runAndExpectSuccess(t, "snapshot", "gc")
-
-	// data block + directory block + manifest block + manifest block from manifest deletion
-	e.runAndVerifyOutputLineCount(t, expectedContentCount, "content", "list")
-
-	// garbage-collect for real, but contents are too recent so won't be deleted
-	e.runAndExpectSuccess(t, "snapshot", "gc", "--delete")
-
-	// data block + directory block + manifest block + manifest block from manifest deletion
-	e.runAndVerifyOutputLineCount(t, expectedContentCount, "content", "list")
-
-	// garbage-collect for real, this time without age limit
-	e.runAndExpectSuccess(t, "snapshot", "gc", "--delete", "--min-age", "0s")
-
-	// two contents are deleted
-	if expectDeleteSucceeds {
-		expectedContentCount -= 2
-	}
-	e.runAndVerifyOutputLineCount(t, expectedContentCount, "content", "list")
 }
 
 func TestDiff(t *testing.T) {

--- a/tests/end_to_end_test/end_to_end_test.go
+++ b/tests/end_to_end_test/end_to_end_test.go
@@ -304,16 +304,19 @@ func TestSnapshotDelete(t *testing.T) {
 	expectFail := false
 	expectSuccess := true
 	for _, tc := range []struct {
+		desc          string
 		mf            deleteArgMaker
 		expectSuccess bool
 	}{
 		{
+			"Test manifest rm function",
 			func(manifestID string, source sourceInfo) []string {
 				return []string{"manifest", "rm", manifestID}
 			},
 			expectSuccess,
 		},
 		{
+			"Specify all source values correctly",
 			func(manifestID string, source sourceInfo) []string {
 				return []string{"snapshot", "delete", manifestID,
 					"--hostname", source.host,
@@ -324,31 +327,48 @@ func TestSnapshotDelete(t *testing.T) {
 			expectSuccess,
 		},
 		{
+			"Specify path and username, using default hostname",
 			func(manifestID string, source sourceInfo) []string {
 				return []string{"snapshot", "delete", manifestID,
-					"--unsafe-ignore-host",
-					"--unsafe-ignore-user",
-					"--unsafe-ignore-path",
+					"--username", source.user,
+					"--path", source.path,
 				}
 			},
 			expectSuccess,
 		},
 		{
-			func(manifestID string, source sourceInfo) []string {
-				return []string{"snapshot", "delete"}
-			},
-			expectFail,
-		},
-		{
-			func(manifestID string, source sourceInfo) []string {
-				return []string{"snapshot", "delete", "some-garbage-manifestID"}
-			},
-			expectFail,
-		},
-		{
+			"Specify path and hostname, using default username",
 			func(manifestID string, source sourceInfo) []string {
 				return []string{"snapshot", "delete", manifestID,
-					"--hostname", "some-wrong-host",
+					"--hostname", source.host,
+					"--path", source.path,
+				}
+			},
+			expectSuccess,
+		},
+		{
+			"No source flags, with unsafe ignore source flag",
+			func(manifestID string, source sourceInfo) []string {
+				return []string{"snapshot", "delete", manifestID,
+					"--unsafe-ignore-source",
+				}
+			},
+			expectSuccess,
+		},
+		{
+			"Specify path only, using default username and hostname",
+			func(manifestID string, source sourceInfo) []string {
+				return []string{"snapshot", "delete", manifestID,
+					"--path", source.path,
+				}
+			},
+			expectSuccess,
+		},
+		{
+			"Specify all source flags, incorrect host name",
+			func(manifestID string, source sourceInfo) []string {
+				return []string{"snapshot", "delete", manifestID,
+					"--hostname", "some-other-host",
 					"--username", source.user,
 					"--path", source.path,
 				}
@@ -356,6 +376,88 @@ func TestSnapshotDelete(t *testing.T) {
 			expectFail,
 		},
 		{
+			"Specify all source flags, incorrect user name",
+			func(manifestID string, source sourceInfo) []string {
+				return []string{"snapshot", "delete", manifestID,
+					"--hostname", source.host,
+					"--username", "some-other-user",
+					"--path", source.path,
+				}
+			},
+			expectFail,
+		},
+		{
+			"Specify all source flags, incorrect path",
+			func(manifestID string, source sourceInfo) []string {
+				return []string{"snapshot", "delete", manifestID,
+					"--hostname", source.host,
+					"--username", source.user,
+					"--path", "some-wrong-path",
+				}
+			},
+			expectFail,
+		},
+		{
+			"Specify all source flags, incorrect hostname, ignore flag set",
+			func(manifestID string, source sourceInfo) []string {
+				return []string{"snapshot", "delete", manifestID,
+					"--unsafe-ignore-source",
+					"--hostname", "some-other-host",
+					"--username", source.user,
+					"--path", source.path,
+				}
+			},
+			expectSuccess,
+		},
+		{
+			"Specify all source flags, incorrect username, ignore flag set",
+			func(manifestID string, source sourceInfo) []string {
+				return []string{"snapshot", "delete", manifestID,
+					"--hostname", source.host,
+					"--username", "some-other-user",
+					"--unsafe-ignore-source",
+					"--path", source.path,
+				}
+			},
+			expectSuccess,
+		},
+		{
+			"Specify all source flags, incorrect path, ignore flag set",
+			func(manifestID string, source sourceInfo) []string {
+				return []string{"snapshot", "delete", manifestID,
+					"--hostname", source.host,
+					"--username", source.user,
+					"--path", "some-wrong-path",
+					"--unsafe-ignore-source",
+				}
+			},
+			expectSuccess,
+		},
+		{
+			"No manifest ID provided",
+			func(manifestID string, source sourceInfo) []string {
+				return []string{"snapshot", "delete"}
+			},
+			expectFail,
+		},
+		{
+			"No manifest ID provided, ignore source flag set",
+			func(manifestID string, source sourceInfo) []string {
+				return []string{"snapshot", "delete",
+					"--unsafe-ignore-source",
+				}
+			},
+			expectFail,
+		},
+		{
+			"Garbage manifest ID provided",
+			func(manifestID string, source sourceInfo) []string {
+				return []string{"snapshot", "delete", "some-garbage-manifestID"}
+			},
+			expectFail,
+		},
+		{
+			"Hostname flag provided but no value input",
 			func(manifestID string, source sourceInfo) []string {
 				return []string{"snapshot", "delete", manifestID,
 					"--hostname",
@@ -366,116 +468,24 @@ func TestSnapshotDelete(t *testing.T) {
 			expectFail,
 		},
 		{
-			func(manifestID string, source sourceInfo) []string {
-				return []string{"snapshot", "delete", manifestID,
-					"--hostname", source.host,
-					"--username", "some-wrong-user",
-					"--path", source.path,
-				}
-			},
-			expectFail,
-		},
-		{
-			func(manifestID string, source sourceInfo) []string {
-				return []string{"snapshot", "delete", manifestID,
-					"--hostname", source.host,
-					"--username", source.user,
-					"--path", "some-wrong-path",
-				}
-			},
-			expectFail,
-		},
-		{
-			func(manifestID string, source sourceInfo) []string {
-				return []string{"snapshot", "delete", manifestID,
-					"--unsafe-ignore-host",
-					"--hostname", "some-wrong-host",
-					"--username", source.user,
-					"--path", source.path,
-				}
-			},
-			expectSuccess,
-		},
-		{
-			func(manifestID string, source sourceInfo) []string {
-				return []string{"snapshot", "delete", manifestID,
-					"--unsafe-ignore-user",
-					"--hostname", source.host,
-					"--username", "some-wrong-user",
-					"--path", source.path,
-				}
-			},
-			expectSuccess,
-		},
-		{
-			func(manifestID string, source sourceInfo) []string {
-				return []string{"snapshot", "delete", manifestID,
-					"--hostname", source.host,
-					"--username", source.user,
-					"--path", "some-wrong-path",
-					"--unsafe-ignore-path",
-				}
-			},
-			expectSuccess,
-		},
-		{
+			"No path provided and no unsafe ignore source flag provided",
 			func(manifestID string, source sourceInfo) []string {
 				return []string{"snapshot", "delete", manifestID}
 			},
 			expectFail,
 		},
 		{
+			"Specify hostname and username with no path provided",
 			func(manifestID string, source sourceInfo) []string {
 				return []string{"snapshot", "delete", manifestID,
-					"--unsafe-ignore-host",
-					"--unsafe-ignore-user",
-				}
-			},
-			expectFail,
-		},
-		{
-			func(manifestID string, source sourceInfo) []string {
-				return []string{"snapshot", "delete", manifestID,
-					"--unsafe-ignore-host",
-					"--unsafe-ignore-path",
-				}
-			},
-			expectFail,
-		},
-		{
-			func(manifestID string, source sourceInfo) []string {
-				return []string{"snapshot", "delete", manifestID,
-					"--unsafe-ignore-user",
-					"--unsafe-ignore-path",
-				}
-			},
-			expectFail,
-		},
-		{
-			func(manifestID string, source sourceInfo) []string {
-				return []string{"snapshot", "delete", manifestID,
-					"--unsafe-ignore-user",
-				}
-			},
-			expectFail,
-		},
-		{
-			func(manifestID string, source sourceInfo) []string {
-				return []string{"snapshot", "delete", manifestID,
-					"--unsafe-ignore-host",
-				}
-			},
-			expectFail,
-		},
-		{
-			func(manifestID string, source sourceInfo) []string {
-				return []string{"snapshot", "delete", manifestID,
-					"--unsafe-ignore-path",
+					"--hostname", source.host,
+					"--username", source.user,
 				}
 			},
 			expectFail,
 		},
 	} {
+		t.Log(tc.desc)
 		testSnapshotDelete(t, tc.mf, tc.expectSuccess)
 	}
 }
@@ -549,16 +559,12 @@ func TestSnapshotDeleteRestore(t *testing.T) {
 
 	// snapshot delete should succeed
 	e.runAndExpectSuccess(t, "snapshot", "delete", snapID,
-		"--unsafe-ignore-host",
-		"--unsafe-ignore-user",
-		"--unsafe-ignore-path",
+		"--unsafe-ignore-source",
 	)
 
 	// Subsequent snapshot delete to the same ID should fail
 	e.runAndExpectFailure(t, "snapshot", "delete", snapID,
-		"--unsafe-ignore-host",
-		"--unsafe-ignore-user",
-		"--unsafe-ignore-path",
+		"--unsafe-ignore-source",
 	)
 
 	// garbage-collect to clean up the root object. Otherwise

--- a/tests/end_to_end_test/end_to_end_test.go
+++ b/tests/end_to_end_test/end_to_end_test.go
@@ -291,168 +291,168 @@ how are you
 	e.runAndVerifyOutputLineCount(t, expectedContentCount, "content", "list")
 }
 
-type manifestDelFunc func(t *testing.T, e *testenv, manifestID string, source sourceInfo)
+type deleteArgMaker func(manifestID string, source sourceInfo) []string
 
 func TestSnapshotDelete(t *testing.T) {
 	expectFail := false
 	expectSuccess := true
 	for _, tc := range []struct {
-		mf            manifestDelFunc
+		mf            deleteArgMaker
 		expectSuccess bool
 	}{
 		{
-			func(t *testing.T, e *testenv, manifestID string, source sourceInfo) {
-				e.runAndExpectSuccess(t, "manifest", "rm", manifestID)
+			func(manifestID string, source sourceInfo) []string {
+				return []string{"manifest", "rm", manifestID}
 			},
 			expectSuccess,
 		},
 		{
-			func(t *testing.T, e *testenv, manifestID string, source sourceInfo) {
-				e.runAndExpectSuccess(t, "snapshot", "delete", manifestID,
+			func(manifestID string, source sourceInfo) []string {
+				return []string{"snapshot", "delete", manifestID,
 					"--host", source.host,
 					"--user", source.user,
 					"--path", source.path,
-				)
+				}
 			},
 			expectSuccess,
 		},
 		{
-			func(t *testing.T, e *testenv, manifestID string, source sourceInfo) {
-				e.runAndExpectSuccess(t, "snapshot", "delete", manifestID,
+			func(manifestID string, source sourceInfo) []string {
+				return []string{"snapshot", "delete", manifestID,
 					"--unsafe-ignore-host",
 					"--unsafe-ignore-user",
 					"--unsafe-ignore-path",
-				)
+				}
 			},
 			expectSuccess,
 		},
 		{
-			func(t *testing.T, e *testenv, manifestID string, source sourceInfo) {
-				e.runAndExpectFailure(t, "snapshot", "delete", manifestID,
+			func(manifestID string, source sourceInfo) []string {
+				return []string{"snapshot", "delete", manifestID,
 					"--host", "some-wrong-host",
 					"--user", source.user,
 					"--path", source.path,
-				)
+				}
 			},
 			expectFail,
 		},
 		{
-			func(t *testing.T, e *testenv, manifestID string, source sourceInfo) {
-				e.runAndExpectFailure(t, "snapshot", "delete", manifestID,
+			func(manifestID string, source sourceInfo) []string {
+				return []string{"snapshot", "delete", manifestID,
 					"--host",
 					"--user", source.user,
 					"--path", source.path,
-				)
+				}
 			},
 			expectFail,
 		},
 		{
-			func(t *testing.T, e *testenv, manifestID string, source sourceInfo) {
-				e.runAndExpectFailure(t, "snapshot", "delete", manifestID,
+			func(manifestID string, source sourceInfo) []string {
+				return []string{"snapshot", "delete", manifestID,
 					"--host", source.host,
 					"--user", "some-wrong-user",
 					"--path", source.path,
-				)
+				}
 			},
 			expectFail,
 		},
 		{
-			func(t *testing.T, e *testenv, manifestID string, source sourceInfo) {
-				e.runAndExpectFailure(t, "snapshot", "delete", manifestID,
+			func(manifestID string, source sourceInfo) []string {
+				return []string{"snapshot", "delete", manifestID,
 					"--host", source.host,
 					"--user", source.user,
 					"--path", "some-wrong-path",
-				)
+				}
 			},
 			expectFail,
 		},
 		{
-			func(t *testing.T, e *testenv, manifestID string, source sourceInfo) {
-				e.runAndExpectSuccess(t, "snapshot", "delete", manifestID,
+			func(manifestID string, source sourceInfo) []string {
+				return []string{"snapshot", "delete", manifestID,
 					"--unsafe-ignore-host",
 					"--host", "some-wrong-host",
 					"--user", source.user,
 					"--path", source.path,
-				)
+				}
 			},
 			expectSuccess,
 		},
 		{
-			func(t *testing.T, e *testenv, manifestID string, source sourceInfo) {
-				e.runAndExpectSuccess(t, "snapshot", "delete", manifestID,
+			func(manifestID string, source sourceInfo) []string {
+				return []string{"snapshot", "delete", manifestID,
 					"--unsafe-ignore-user",
 					"--host", source.host,
 					"--user", "some-wrong-user",
 					"--path", source.path,
-				)
+				}
 			},
 			expectSuccess,
 		},
 		{
-			func(t *testing.T, e *testenv, manifestID string, source sourceInfo) {
-				e.runAndExpectSuccess(t, "snapshot", "delete", manifestID,
+			func(manifestID string, source sourceInfo) []string {
+				return []string{"snapshot", "delete", manifestID,
 					"--host", source.host,
 					"--user", source.user,
 					"--path", "some-wrong-path",
 					"--unsafe-ignore-path",
-				)
+				}
 			},
 			expectSuccess,
 		},
 		{
-			func(t *testing.T, e *testenv, manifestID string, source sourceInfo) {
-				e.runAndExpectFailure(t, "snapshot", "delete", manifestID)
+			func(manifestID string, source sourceInfo) []string {
+				return []string{"snapshot", "delete", manifestID}
 			},
 			expectFail,
 		},
 		{
-			func(t *testing.T, e *testenv, manifestID string, source sourceInfo) {
-				e.runAndExpectFailure(t, "snapshot", "delete", manifestID,
+			func(manifestID string, source sourceInfo) []string {
+				return []string{"snapshot", "delete", manifestID,
 					"--unsafe-ignore-host",
 					"--unsafe-ignore-user",
-				)
+				}
 			},
 			expectFail,
 		},
 		{
-			func(t *testing.T, e *testenv, manifestID string, source sourceInfo) {
-				e.runAndExpectFailure(t, "snapshot", "delete", manifestID,
+			func(manifestID string, source sourceInfo) []string {
+				return []string{"snapshot", "delete", manifestID,
 					"--unsafe-ignore-host",
 					"--unsafe-ignore-path",
-				)
+				}
 			},
 			expectFail,
 		},
 		{
-			func(t *testing.T, e *testenv, manifestID string, source sourceInfo) {
-				e.runAndExpectFailure(t, "snapshot", "delete", manifestID,
+			func(manifestID string, source sourceInfo) []string {
+				return []string{"snapshot", "delete", manifestID,
 					"--unsafe-ignore-user",
 					"--unsafe-ignore-path",
-				)
+				}
 			},
 			expectFail,
 		},
 		{
-			func(t *testing.T, e *testenv, manifestID string, source sourceInfo) {
-				e.runAndExpectFailure(t, "snapshot", "delete", manifestID,
+			func(manifestID string, source sourceInfo) []string {
+				return []string{"snapshot", "delete", manifestID,
 					"--unsafe-ignore-user",
-				)
+				}
 			},
 			expectFail,
 		},
 		{
-			func(t *testing.T, e *testenv, manifestID string, source sourceInfo) {
-				e.runAndExpectFailure(t, "snapshot", "delete", manifestID,
+			func(manifestID string, source sourceInfo) []string {
+				return []string{"snapshot", "delete", manifestID,
 					"--unsafe-ignore-host",
-				)
+				}
 			},
 			expectFail,
 		},
 		{
-			func(t *testing.T, e *testenv, manifestID string, source sourceInfo) {
-				e.runAndExpectFailure(t, "snapshot", "delete", manifestID,
+			func(manifestID string, source sourceInfo) []string {
+				return []string{"snapshot", "delete", manifestID,
 					"--unsafe-ignore-path",
-				)
+				}
 			},
 			expectFail,
 		},
@@ -461,7 +461,7 @@ func TestSnapshotDelete(t *testing.T) {
 	}
 }
 
-func testSnapshotDelete(t *testing.T, mf manifestDelFunc, expectDeleteSucceeds bool) {
+func testSnapshotDelete(t *testing.T, argMaker deleteArgMaker, expectDeleteSucceeds bool) {
 	e := newTestEnv(t)
 	defer e.cleanup(t)
 	defer e.runAndExpectSuccess(t, "repo", "disconnect")
@@ -490,7 +490,12 @@ how are you
 		for _, ss := range source.snapshots {
 			manifestID := ss.snapshotID
 			t.Logf("manifestID: %v", manifestID)
-			mf(t, e, manifestID, source)
+			args := argMaker(manifestID, source)
+			if expectDeleteSucceeds {
+				e.runAndExpectSuccess(t, args...)
+			} else {
+				e.runAndExpectFailure(t, args...)
+			}
 		}
 	}
 

--- a/tests/end_to_end_test/end_to_end_test.go
+++ b/tests/end_to_end_test/end_to_end_test.go
@@ -161,8 +161,8 @@ func TestEndToEnd(t *testing.T) {
 
 	dir3 := filepath.Join(e.dataDir, "dir3")
 	createDirectory(t, dir3, 3)
-	e.runAndExpectSuccess(t, "snapshot", "create", "--hostname", "bar", "--username", "foo", dir3)
-	e.runAndExpectSuccess(t, "snapshot", "list", "--hostname", "bar", "--username", "foo", dir3)
+	e.runAndExpectSuccess(t, "snapshot", "create", "--hostnamename", "bar", "--usernamename", "foo", dir3)
+	e.runAndExpectSuccess(t, "snapshot", "list", "--hostnamename", "bar", "--usernamename", "foo", dir3)
 
 	sources := listSnapshotsAndExpectSuccess(t, e)
 	if got, want := len(sources), 3; got != want {
@@ -250,8 +250,8 @@ func TestSnapshotDelete(t *testing.T) {
 		{
 			func(manifestID string, source sourceInfo) []string {
 				return []string{"snapshot", "delete", manifestID,
-					"--host", source.host,
-					"--user", source.user,
+					"--hostname", source.host,
+					"--username", source.user,
 					"--path", source.path,
 				}
 			},
@@ -270,8 +270,8 @@ func TestSnapshotDelete(t *testing.T) {
 		{
 			func(manifestID string, source sourceInfo) []string {
 				return []string{"snapshot", "delete", manifestID,
-					"--host", "some-wrong-host",
-					"--user", source.user,
+					"--hostname", "some-wrong-host",
+					"--username", source.user,
 					"--path", source.path,
 				}
 			},
@@ -280,8 +280,8 @@ func TestSnapshotDelete(t *testing.T) {
 		{
 			func(manifestID string, source sourceInfo) []string {
 				return []string{"snapshot", "delete", manifestID,
-					"--host",
-					"--user", source.user,
+					"--hostname",
+					"--username", source.user,
 					"--path", source.path,
 				}
 			},
@@ -290,8 +290,8 @@ func TestSnapshotDelete(t *testing.T) {
 		{
 			func(manifestID string, source sourceInfo) []string {
 				return []string{"snapshot", "delete", manifestID,
-					"--host", source.host,
-					"--user", "some-wrong-user",
+					"--hostname", source.host,
+					"--username", "some-wrong-user",
 					"--path", source.path,
 				}
 			},
@@ -300,8 +300,8 @@ func TestSnapshotDelete(t *testing.T) {
 		{
 			func(manifestID string, source sourceInfo) []string {
 				return []string{"snapshot", "delete", manifestID,
-					"--host", source.host,
-					"--user", source.user,
+					"--hostname", source.host,
+					"--username", source.user,
 					"--path", "some-wrong-path",
 				}
 			},
@@ -311,8 +311,8 @@ func TestSnapshotDelete(t *testing.T) {
 			func(manifestID string, source sourceInfo) []string {
 				return []string{"snapshot", "delete", manifestID,
 					"--unsafe-ignore-host",
-					"--host", "some-wrong-host",
-					"--user", source.user,
+					"--hostname", "some-wrong-host",
+					"--username", source.user,
 					"--path", source.path,
 				}
 			},
@@ -322,8 +322,8 @@ func TestSnapshotDelete(t *testing.T) {
 			func(manifestID string, source sourceInfo) []string {
 				return []string{"snapshot", "delete", manifestID,
 					"--unsafe-ignore-user",
-					"--host", source.host,
-					"--user", "some-wrong-user",
+					"--hostname", source.host,
+					"--username", "some-wrong-user",
 					"--path", source.path,
 				}
 			},
@@ -332,8 +332,8 @@ func TestSnapshotDelete(t *testing.T) {
 		{
 			func(manifestID string, source sourceInfo) []string {
 				return []string{"snapshot", "delete", manifestID,
-					"--host", source.host,
-					"--user", source.user,
+					"--hostname", source.host,
+					"--username", source.user,
 					"--path", "some-wrong-path",
 					"--unsafe-ignore-path",
 				}


### PR DESCRIPTION
Implemented `snapshot delete` command. Behaves similarly to `manifest rm`, but with extra verification steps. Checks that the ID points to a snapshot, checks that the host name, user name, and path provided by flag match the source of the snapshot ID. Command will fail if they do not match, except if given `--unsafe-ignore-[host|user|path]` flags, which will bypass the associated safety requirement and delete anyway.

Enhanced end to end test for `manifest rm` to verify expected behavior.