### PR TITLE
Snapshot restore command

### DIFF
--- a/cli/command_restore.go
+++ b/cli/command_restore.go
@@ -51,7 +51,7 @@ func runRestoreCommand(ctx context.Context, rep *repo.Repository) error {
 		return err
 	}
 
-	return snapshotfs.Restore(ctx, rep, *restoreCommandTargetPath, oid)
+	return snapshotfs.RestoreRoot(ctx, rep, *restoreCommandTargetPath, oid)
 }
 
 func init() {

--- a/cli/command_snapshot_restore.go
+++ b/cli/command_snapshot_restore.go
@@ -1,0 +1,39 @@
+package cli
+
+import (
+	"context"
+	"os"
+
+	"github.com/kopia/kopia/fs/localfs"
+	"github.com/kopia/kopia/repo"
+	"github.com/kopia/kopia/repo/manifest"
+	"github.com/kopia/kopia/snapshot"
+	"github.com/kopia/kopia/snapshot/snapshotfs"
+)
+
+var (
+	snapshotRestoreCommand    = snapshotCommands.Command("restore", "Restore a snapshot from the snapshot ID to the given target path")
+	snapshotRestoreSnapID     = snapshotRestoreCommand.Arg("id", "Snapshot ID to be restored").Required().String()
+	snapshotRestoreTargetPath = snapshotRestoreCommand.Arg("target-path", "Path of the directory for the contents to be restored").Required().String()
+)
+
+func runSnapRestoreCommand(ctx context.Context, rep *repo.Repository) error {
+	manifestID := manifest.ID(*snapshotRestoreSnapID)
+	m := &snapshot.Manifest{}
+	err := rep.Manifests.Get(ctx, manifestID, m)
+	if err != nil {
+		_ = os.MkdirAll(*snapshotRestoreTargetPath, 0700)
+		return err
+	}
+
+	rootEntry, err := snapshotfs.SnapshotRoot(rep, m)
+	if err != nil {
+		_ = os.MkdirAll(*snapshotRestoreTargetPath, 0700)
+		return err
+	}
+	return localfs.Copy(ctx, *snapshotRestoreTargetPath, rootEntry)
+}
+
+func init() {
+	snapshotRestoreCommand.Action(repositoryAction(runSnapRestoreCommand))
+}

--- a/cli/command_snapshot_restore.go
+++ b/cli/command_snapshot_restore.go
@@ -3,10 +3,8 @@ package cli
 import (
 	"context"
 
-	"github.com/kopia/kopia/fs/localfs"
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/manifest"
-	"github.com/kopia/kopia/snapshot"
 	"github.com/kopia/kopia/snapshot/snapshotfs"
 )
 
@@ -17,18 +15,7 @@ var (
 )
 
 func runSnapRestoreCommand(ctx context.Context, rep *repo.Repository) error {
-	manifestID := manifest.ID(*snapshotRestoreSnapID)
-	m := &snapshot.Manifest{}
-	err := rep.Manifests.Get(ctx, manifestID, m)
-	if err != nil {
-		return err
-	}
-
-	rootEntry, err := snapshotfs.SnapshotRoot(rep, m)
-	if err != nil {
-		return err
-	}
-	return localfs.Copy(ctx, *snapshotRestoreTargetPath, rootEntry)
+	return snapshotfs.Restore(ctx, rep, *snapshotRestoreTargetPath, manifest.ID(*snapshotRestoreSnapID))
 }
 
 func init() {

--- a/cli/command_snapshot_restore.go
+++ b/cli/command_snapshot_restore.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"context"
-	"os"
 
 	"github.com/kopia/kopia/fs/localfs"
 	"github.com/kopia/kopia/repo"
@@ -22,13 +21,11 @@ func runSnapRestoreCommand(ctx context.Context, rep *repo.Repository) error {
 	m := &snapshot.Manifest{}
 	err := rep.Manifests.Get(ctx, manifestID, m)
 	if err != nil {
-		_ = os.MkdirAll(*snapshotRestoreTargetPath, 0700)
 		return err
 	}
 
 	rootEntry, err := snapshotfs.SnapshotRoot(rep, m)
 	if err != nil {
-		_ = os.MkdirAll(*snapshotRestoreTargetPath, 0700)
 		return err
 	}
 	return localfs.Copy(ctx, *snapshotRestoreTargetPath, rootEntry)

--- a/snapshot/manager.go
+++ b/snapshot/manager.go
@@ -58,8 +58,8 @@ func ListSnapshots(ctx context.Context, rep *repo.Repository, si SourceInfo) ([]
 	return LoadSnapshots(ctx, rep, entryIDs(entries))
 }
 
-// loadSnapshot loads and parses a snapshot with a given ID.
-func loadSnapshot(ctx context.Context, rep *repo.Repository, manifestID manifest.ID) (*Manifest, error) {
+// LoadSnapshot loads and parses a snapshot with a given ID.
+func LoadSnapshot(ctx context.Context, rep *repo.Repository, manifestID manifest.ID) (*Manifest, error) {
 	sm := &Manifest{}
 	if err := rep.Manifests.Get(ctx, manifestID, sm); err != nil {
 		return nil, errors.Wrap(err, "unable to find manifest entries")
@@ -105,7 +105,7 @@ func LoadSnapshots(ctx context.Context, rep *repo.Repository, manifestIDs []mani
 		go func(i int, n manifest.ID) {
 			defer func() { <-sem }()
 
-			m, err := loadSnapshot(ctx, rep, n)
+			m, err := LoadSnapshot(ctx, rep, n)
 			if err != nil {
 				log.Warningf("unable to parse snapshot manifest %v: %v", n, err)
 				return

--- a/snapshot/snapshotfs/restore.go
+++ b/snapshot/snapshotfs/restore.go
@@ -3,12 +3,13 @@ package snapshotfs
 import (
 	"context"
 
+	"github.com/pkg/errors"
+
 	"github.com/kopia/kopia/fs/localfs"
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/manifest"
 	"github.com/kopia/kopia/repo/object"
 	"github.com/kopia/kopia/snapshot"
-	"github.com/pkg/errors"
 )
 
 // Restore walks a snapshot root with given snapshot ID and restores it to the local filesystem
@@ -21,10 +22,12 @@ func Restore(ctx context.Context, rep *repo.Repository, targetPath string, snapI
 	if m.RootEntry == nil {
 		return errors.Errorf("No root entry found in manifest (%v)", snapID)
 	}
+
 	rootEntry, err := SnapshotRoot(rep, m)
 	if err != nil {
 		return err
 	}
+
 	return localfs.Copy(ctx, targetPath, rootEntry)
 }
 

--- a/snapshot/snapshotfs/restore.go
+++ b/snapshot/snapshotfs/restore.go
@@ -5,10 +5,30 @@ import (
 
 	"github.com/kopia/kopia/fs/localfs"
 	"github.com/kopia/kopia/repo"
+	"github.com/kopia/kopia/repo/manifest"
 	"github.com/kopia/kopia/repo/object"
+	"github.com/kopia/kopia/snapshot"
+	"github.com/pkg/errors"
 )
 
-// Restore walks a snapshot root with given object ID and restores it to the local filesystem
-func Restore(ctx context.Context, rep *repo.Repository, targetPath string, oid object.ID) error {
+// Restore walks a snapshot root with given snapshot ID and restores it to the local filesystem
+func Restore(ctx context.Context, rep *repo.Repository, targetPath string, snapID manifest.ID) error {
+	m, err := snapshot.LoadSnapshot(ctx, rep, snapID)
+	if err != nil {
+		return err
+	}
+
+	if m.RootEntry == nil {
+		return errors.Errorf("No root entry found in manifest (%v)", snapID)
+	}
+	rootEntry, err := SnapshotRoot(rep, m)
+	if err != nil {
+		return err
+	}
+	return localfs.Copy(ctx, targetPath, rootEntry)
+}
+
+// RestoreRoot walks a snapshot root with given object ID and restores it to the local filesystem
+func RestoreRoot(ctx context.Context, rep *repo.Repository, targetPath string, oid object.ID) error {
 	return localfs.Copy(ctx, targetPath, DirectoryEntry(rep, oid, nil))
 }

--- a/tests/end_to_end_test/end_to_end_test.go
+++ b/tests/end_to_end_test/end_to_end_test.go
@@ -376,9 +376,11 @@ func TestRestoreCommand(t *testing.T) {
 	if got, want := len(si), 1; got != want {
 		t.Fatalf("got %v sources, wanted %v", got, want)
 	}
+
 	if got, want := len(si[0].snapshots), 1; got != want {
 		t.Fatalf("got %v snapshots, wanted %v", got, want)
 	}
+
 	snapID := si[0].snapshots[0].snapshotID
 	rootID := si[0].snapshots[0].objectID
 
@@ -450,9 +452,11 @@ func TestSnapshotRestore(t *testing.T) {
 	if got, want := len(si), 1; got != want {
 		t.Fatalf("got %v sources, wanted %v", got, want)
 	}
+
 	if got, want := len(si[0].snapshots), 1; got != want {
 		t.Fatalf("got %v snapshots, wanted %v", got, want)
 	}
+
 	snapID := si[0].snapshots[0].snapshotID
 	rootID := si[0].snapshots[0].objectID
 

--- a/tests/end_to_end_test/end_to_end_test.go
+++ b/tests/end_to_end_test/end_to_end_test.go
@@ -467,6 +467,7 @@ func TestSnapshotRestore(t *testing.T) {
 	e.runAndExpectFailure(t, "snapshot", "restore", rootID, restoreFailDir)
 
 	// Attempt to restore snapshot with an already-existing target directory
+	_ = os.MkdirAll(restoreFailDir, 0700)
 	e.runAndExpectFailure(t, "snapshot", "restore", snapID, restoreFailDir)
 
 	// Restore last snapshot using the snapshot ID

--- a/tests/end_to_end_test/end_to_end_test.go
+++ b/tests/end_to_end_test/end_to_end_test.go
@@ -759,18 +759,3 @@ func assertNoError(t *testing.T, err error) {
 		t.Errorf("err: %v", err)
 	}
 }
-
-func getLastSnapshotRootID(t *testing.T, listOutput []string) string {
-	t.Helper()
-
-	if len(listOutput) == 0 {
-		t.Fatal("Expected non-empty snapshot list")
-	}
-
-	f := strings.Fields(listOutput[len(listOutput)-1])
-	if len(f) < 4 {
-		t.Fatal("Could not parse snapshot list output: ", listOutput)
-	}
-
-	return f[3]
-}


### PR DESCRIPTION
Snapshot restore will take a snapshot ID and restore the
associated snapshot to the target path.
- Looks up the manifest with the snapshot ID
- Gets the snapshot root entry
- Copies the snapshot from the root entry to the target path

Because it uses the parent manifest with the copied permissions,
the restored directory will have the permissions of the original
source directory.

Added an end to end test similar to the `restore` command for `snapshot restore`, without the permissions workaround. Added checks that `restore` does not restore from snapshot ID and `snap restore` does not restore from root ID.