### PR TITLE
GC mark phase (1)

### DIFF
--- a/repo/content/info.go
+++ b/repo/content/info.go
@@ -1,6 +1,7 @@
 package content
 
 import (
+	"sort"
 	"time"
 
 	"github.com/kopia/kopia/repo/blob"
@@ -21,6 +22,11 @@ func (i ID) Prefix() ID {
 // HasPrefix determines if the given ID has a non-empty prefix.
 func (i ID) HasPrefix() bool {
 	return len(i)%2 == 1
+}
+
+// SortIDs sorts ids in place
+func SortIDs(ids []ID) {
+	sort.Slice(ids, func(i int, j int) bool { return ids[i] < ids[j] })
 }
 
 // Info is an information about a single piece of content managed by Manager.

--- a/snapshot/gc/gc.go
+++ b/snapshot/gc/gc.go
@@ -79,7 +79,7 @@ func Run(ctx context.Context, rep *repo.DirectRepository, params maintenance.Sna
 		return Stats{}, errors.Wrap(err, "unable to list snapshot manifest IDs")
 	}
 
-	st, err := markUnusedContent(ctx, rep, snapIDs, minContentAge, gcDelete)
+	st, err := markUnusedContent(ctx, rep, snapIDs, params.MinContentAge, gcDelete)
 	if err != nil {
 		return st, err
 	}

--- a/snapshot/gc/gc_test.go
+++ b/snapshot/gc/gc_test.go
@@ -1,0 +1,261 @@
+package gc
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/hex"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/repo"
+	"github.com/kopia/kopia/repo/blob/filesystem"
+	"github.com/kopia/kopia/repo/content"
+	"github.com/kopia/kopia/repo/manifest"
+)
+
+func Test_deleteUnused(t *testing.T) {
+	tests := []struct {
+		name         string
+		snapCount    uint
+		contentCount int
+		deleteCount  int
+		batchSize    int
+	}{
+		{
+			name:         "with no snap ids",
+			snapCount:    0,
+			contentCount: 4,
+			deleteCount:  3,
+			batchSize:    5,
+		},
+
+		{
+			name:         "with single snap id",
+			snapCount:    1,
+			contentCount: 4,
+			deleteCount:  3,
+			batchSize:    5,
+		},
+
+		{
+			name:         "0 contents to delete",
+			snapCount:    3,
+			contentCount: 4,
+			deleteCount:  0,
+			batchSize:    5,
+		},
+
+		{
+			name:         "delete some of the content",
+			snapCount:    3,
+			contentCount: 8,
+			deleteCount:  6,
+			batchSize:    10,
+		},
+
+		{
+			name:         "delete all the content",
+			snapCount:    3,
+			contentCount: 9,
+			deleteCount:  9,
+			batchSize:    10,
+		},
+
+		{
+			name:         "delete count same as batch size",
+			snapCount:    3,
+			contentCount: 12,
+			deleteCount:  10,
+			batchSize:    10,
+		},
+
+		{
+			name:         "delete count larger than batch size",
+			snapCount:    3,
+			contentCount: 21,
+			deleteCount:  19,
+			batchSize:    10,
+		},
+
+		{
+			name:         "delete multiple batches",
+			snapCount:    3,
+			contentCount: 155,
+			deleteCount:  147,
+			batchSize:    50,
+		},
+	}
+
+	ctx := context.Background()
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			check := assert.New(t)
+			r := createAndOpenRepo(t)
+			defer r.Close(t)
+
+			cids := writeContents(ctx, t, r.repo.Content, tt.contentCount)
+			snaps := nManifestIDs(t, tt.snapCount)
+			toDeleteCh := make(chan content.ID)
+
+			go func() {
+				defer close(toDeleteCh)
+				for _, id := range cids[:tt.deleteCount] {
+					toDeleteCh <- id
+				}
+			}()
+
+			check.NoError(r.repo.Flush(ctx))
+			// Ensure that deleted contents have a newer time stamp
+			time.Sleep(time.Second)
+
+			err := deleteUnused(ctx, r.repo, snaps, toDeleteCh, tt.batchSize)
+			check.NoError(err, "unexpected error")
+
+			// verify that all the contents sent through the channel were
+			// deleted and nothing else
+			verifyContentDeletedState(ctx, t, r.repo.Content, cids[:tt.deleteCount], true)
+			verifyContentDeletedState(ctx, t, r.repo.Content, cids[tt.deleteCount:], false)
+
+			// check: are there GC manifests?
+			gcMans, err := r.repo.Manifests.Find(ctx, markManifestLabels())
+			check.NoError(err)
+			check.Len(gcMans, (tt.deleteCount+tt.batchSize-1)/tt.batchSize, "expected a single GC mark manifest")
+
+			var foundGCContentCount int
+
+			opts := content.IterateOptions{Range: content.PrefixRange(ContentPrefix)}
+			err = r.repo.Content.IterateContents(ctx, opts, func(i content.Info) error {
+				foundGCContentCount++
+				return nil
+			})
+
+			check.NoError(err)
+
+			check.Equal(len(gcMans), foundGCContentCount, "GC details content count does not match number of GC mark manifests")
+		})
+	}
+}
+
+type testRepo struct {
+	stateDir string
+	repo     *repo.DirectRepository
+}
+
+func createAndOpenRepo(t *testing.T) testRepo {
+	const masterPassword = "foo"
+
+	t.Helper()
+
+	ctx := context.Background()
+	check := require.New(t)
+
+	stateDir, err := ioutil.TempDir("", "manifest-test")
+	check.NoError(err, "cannot create temp directory")
+	t.Log("repo dir:", stateDir)
+
+	repoDir := filepath.Join(stateDir, "repo")
+	check.NoError(os.MkdirAll(repoDir, 0700), "cannot create repository directory")
+
+	storage, err := filesystem.New(context.Background(), &filesystem.Options{
+		Path: repoDir,
+	})
+	check.NoError(err, "cannot create storage directory")
+
+	err = repo.Initialize(ctx, storage, &repo.NewRepositoryOptions{}, masterPassword)
+	check.NoError(err, "cannot create repository")
+
+	configFile := filepath.Join(stateDir, configFileName)
+	connOpts := repo.ConnectOptions{
+		CachingOptions: content.CachingOptions{
+			CacheDirectory: filepath.Join(stateDir, "cache"),
+		},
+	}
+	err = repo.Connect(ctx, configFile, storage, masterPassword, &connOpts)
+
+	check.NoError(err, "unable to connect to repository")
+
+	rep, err := repo.Open(ctx, configFile, masterPassword, &repo.Options{})
+	check.NoError(err, "unable to open repository")
+
+	return testRepo{
+		stateDir: stateDir,
+		repo:     rep,
+	}
+}
+
+func (r *testRepo) Close(t *testing.T) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	if r.repo != nil {
+		assert.NoError(t, r.repo.Close(ctx), "unable to close repository")
+	}
+
+	if r.stateDir != "" {
+		configFile := filepath.Join(r.stateDir, configFileName)
+		err := repo.Disconnect(ctx, configFile)
+
+		require.NoError(t, err, "failed to disconnect repo with config file: ", configFile)
+		assert.NoError(t, os.RemoveAll(r.stateDir), "unable to cleanup test state directory")
+	}
+}
+
+func nManifestIDs(t *testing.T, n uint) []manifest.ID {
+	ids := make([]manifest.ID, n)
+
+	for i := range ids {
+		ids[i] = manifest.ID(makeRandomHexString(t, 32))
+	}
+
+	return ids
+}
+
+func makeRandomHexString(t *testing.T, length int) string {
+	t.Helper()
+
+	b := make([]byte, (length-1)/2+1)
+	_, err := rand.Read(b) // nolint:gosec
+
+	require.NoError(t, err)
+
+	return hex.EncodeToString(b)
+}
+
+func verifyContentDeletedState(ctx context.Context, t *testing.T, cm *content.Manager, cids []content.ID, wantDeleted bool) {
+	t.Helper()
+
+	for _, id := range cids {
+		info, err := cm.ContentInfo(ctx, id)
+		assert.NoError(t, err)
+		assert.Equal(t, wantDeleted, info.Deleted, "content deleted state does not match")
+	}
+}
+
+func writeContents(ctx context.Context, t *testing.T, cm *content.Manager, n int) []content.ID {
+	t.Helper()
+
+	b := make([]byte, 8)
+	ids := make([]content.ID, 0, n)
+
+	for i := rand.Uint64(); n > 0; n-- {
+		binary.BigEndian.PutUint64(b, i)
+		i++
+
+		id, err := cm.WriteContent(ctx, b, "")
+		assert.NoError(t, err, "Failed to write content")
+
+		ids = append(ids, id)
+	}
+
+	return ids
+}

--- a/snapshot/gc/manifest.go
+++ b/snapshot/gc/manifest.go
@@ -1,0 +1,100 @@
+package gc
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/kopia/kopia/repo"
+	"github.com/kopia/kopia/repo/content"
+	"github.com/kopia/kopia/repo/manifest"
+)
+
+// ContentPrefix is the prefix used for GC related content
+const ContentPrefix content.ID = "g"
+
+const markManifestType = "gc-mark"
+
+// MarkManifest represents information about a single GC mark run
+type MarkManifest struct {
+	ID manifest.ID `json:"-"`
+
+	StartTime time.Time `json:"startTime"`
+	EndTime   time.Time `json:"endTime"`
+
+	DetailsID content.ID `json:"detailsID"`
+}
+
+// MarkDetails contains metadata about a GC mark phase, which is later used
+// by the GC delete phase
+type MarkDetails struct {
+	// Snapshots that were visible to a GC run.
+	Snapshots []manifest.ID `json:"liveSnapshots,omitempty"`
+	// Set of contents marked for deletion by the GC mark phase.
+	MarkedContent []content.ID `json:"markedContent,omitempty"`
+}
+
+func markContentsDeleted(ctx context.Context, rep *repo.DirectRepository, snaps []manifest.ID, toDelete []content.ID) error {
+	if err := markContentAndCreateManifest(ctx, rep, snaps, toDelete); err != nil {
+		return err
+	}
+
+	return rep.Content.Flush(ctx)
+}
+
+func markContentAndCreateManifest(ctx context.Context, rep *repo.DirectRepository, snaps []manifest.ID, toDelete []content.ID) error {
+	// create mark details manifest, get back an id
+	m := MarkManifest{
+		StartTime: rep.Time().UTC(),
+	}
+
+	did, err := writeMarkDetails(ctx, rep, snaps, toDelete)
+	if err != nil {
+		return err
+	}
+
+	m.DetailsID = did
+
+	// disable flushing to ensure that the mark manifest and the deleted entries
+	// are in a single index pack. May want to do this earlier to include the
+	// details manifest
+	rep.Content.DisableIndexFlush(ctx)
+	defer rep.Content.EnableIndexFlush(ctx)
+
+	// may want to have a batch call for this.
+	for _, cid := range toDelete {
+		if err2 := rep.Content.DeleteContent(ctx, cid); err2 != nil {
+			return err2
+		}
+	}
+
+	m.EndTime = rep.Time().UTC()
+
+	if _, err = rep.Manifests.Put(ctx, markManifestLabels(), m); err != nil {
+		return err
+	}
+
+	return rep.Manifests.Flush(ctx)
+}
+
+func writeMarkDetails(ctx context.Context, rep *repo.DirectRepository, snaps []manifest.ID, toDelete []content.ID) (content.ID, error) {
+	content.SortIDs(toDelete)
+
+	details := MarkDetails{
+		Snapshots:     snaps,
+		MarkedContent: toDelete,
+	}
+
+	b, err := json.Marshal(details)
+	if err != nil {
+		return "", nil
+	}
+
+	return rep.Content.WriteContent(ctx, b, ContentPrefix)
+}
+
+func markManifestLabels() map[string]string {
+	return map[string]string{
+		manifest.TypeLabelKey: markManifestType,
+	}
+}

--- a/snapshot/gc/manifest_test.go
+++ b/snapshot/gc/manifest_test.go
@@ -1,0 +1,92 @@
+package gc
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/repo/content"
+)
+
+const configFileName = "kopia.config"
+
+func TestMarkContentsDeleted(t *testing.T) {
+	const contentCount = 10
+
+	ctx := context.Background()
+	check := require.New(t)
+	th := createAndOpenRepo(t)
+
+	defer th.Close(t)
+
+	// setup: create contents
+	cids := writeContents(ctx, t, th.repo.Content, contentCount)
+
+	check.NoError(th.repo.Flush(ctx))
+
+	// Ensure that deleted contents have a newer time stamp
+	time.Sleep(time.Second)
+
+	// delete half the contents
+	snaps := nManifestIDs(t, 3)
+
+	toDelete := cids[0:5]
+	err := markContentsDeleted(ctx, th.repo, snaps, toDelete)
+	check.NoError(err)
+
+	// check: is there a GC manifest?
+	gcMans, err := th.repo.Manifests.Find(ctx, markManifestLabels())
+	check.NoError(err)
+	check.Len(gcMans, 1, "expected a single GC mark manifest")
+
+	var man MarkManifest
+	_, err = th.repo.Manifests.Get(ctx, gcMans[0].ID, &man)
+	check.NoError(err)
+
+	// check: is there a content with GC mark details?
+	var gcContents []content.ID
+
+	opts := content.IterateOptions{Range: content.PrefixRange(ContentPrefix)}
+	err = th.repo.Content.IterateContents(ctx, opts, func(i content.Info) error {
+		gcContents = append(gcContents, i.ID)
+		return nil
+	})
+
+	check.NoError(err)
+
+	check.Len(gcContents, 1, "there must be a single GC details content")
+
+	check.Equal(man.DetailsID, gcContents[0], "ID of the GC details content must match the mark manifest DetailsID field")
+
+	// deserialize mark details
+	b, err := th.repo.Content.GetContent(ctx, man.DetailsID)
+	check.NoError(err)
+	check.NotNil(b)
+
+	var markDetails MarkDetails
+
+	check.NoError(json.Unmarshal(b, &markDetails))
+
+	check.Equal(snaps, markDetails.Snapshots, "markDetails.Snapshots must be the same as 'snaps'")
+
+	check.Equal(toDelete, markDetails.MarkedContent, "MarkedContent must have the ids of the removed contents")
+
+	// verify content not in `toDelete` was not deleted
+	verifyContentDeletedState(ctx, t, th.repo.Content, cids[5:], false)
+
+	// verify content in 'toDelete' was marked as deleted
+	verifyContentDeletedState(ctx, t, th.repo.Content, toDelete, true)
+}
+
+func TestSortContentIDs(t *testing.T) {
+	cids := []content.ID{"x", "c", "b", "a"}
+	content.SortIDs(cids)
+
+	for i, id := range cids[1:] {
+		prev, current := string(cids[i]), string(id)
+		require.LessOrEqual(t, prev, current, "content IDs not sorted")
+	}
+}

--- a/tests/end_to_end_test/snapshot_gc_test.go
+++ b/tests/end_to_end_test/snapshot_gc_test.go
@@ -66,6 +66,8 @@ how are you
 	e.RunAndExpectSuccess(t, "snapshot", "gc", "--delete", "--min-age", "0s")
 
 	// two contents are deleted
-	expectedContentCount -= 2
+	// the gc-mark phase should produce 2 new contents: one for the gc-mark
+	// details and one for the gc manifest, so the net number of expected
+	// contents should stay the same.
 	e.RunAndVerifyOutputLineCount(t, expectedContentCount, "content", "list")
 }


### PR DESCRIPTION
Create a manifest and a content chunk with detailed metadata for the GC-mark phase.
The manifest details includes:
* Timestamp for the GC mark phase
* The id of the content chunk that has the GC-mark metadata details.

The detailed metadata chunk contains:
* Ids of the live snapshots that were visible to the GC-mark phase.
* Ids of content chunks that were marked-deleted by the GC mark phase.
* Currently unpopulated, theres a list with the deleted snapshots visible to the GC-mark phase. It is for a future optimization and the required info (deleted snapshots) is not available. We could remove it for now.