### PR TITLE
[round 2] Snapshot failure test and fix kopia panic for non-executable directories

### DIFF
--- a/tests/end_to_end_test/snapshot_fail_test.go
+++ b/tests/end_to_end_test/snapshot_fail_test.go
@@ -180,6 +180,7 @@ func TestSnapshotFail(t *testing.T) {
 		},
 	} {
 		t.Log(tc.desc)
+
 		uniqueSourceMap[tc.snapSource] = struct{}{}
 		restoreDir := fmt.Sprintf("%s%d", restoreDirPrefix, ti)
 		numSuccessfulSnapshots += testPermissions(e, t, tc.snapSource, tc.modifyEntry, restoreDir, tc.expectSuccess)
@@ -189,6 +190,7 @@ func TestSnapshotFail(t *testing.T) {
 	// a snap list output
 	si := e.ListSnapshotsAndExpectSuccess(t)
 	expSources := len(uniqueSourceMap)
+
 	if got, want := len(si), expSources; got != want {
 		t.Fatalf("got %v sources, wanted %v", got, want)
 	}
@@ -255,7 +257,6 @@ func testPermissions(e *testenv.CLITest, t *testing.T, source, modifyEntry, rest
 
 			// Expect that since the snapshot succeeded, the data can be restored
 			e.RunAndExpectSuccess(t, "snapshot", "restore", snapID, restoreDir)
-
 		} else {
 			e.RunAndExpectFailure(t, "snapshot", "create", source)
 		}
@@ -271,12 +272,15 @@ func testPermissions(e *testenv.CLITest, t *testing.T, source, modifyEntry, rest
 
 func parseSnapID(t *testing.T, lines []string) string {
 	pattern := regexp.MustCompile(`uploaded snapshot ([\S]+)`)
+
 	for _, l := range lines {
 		match := pattern.FindAllStringSubmatch(l, 1)
 		if len(match) > 0 && len(match[0]) > 1 {
 			return match[0][1]
 		}
 	}
+
 	t.Fatal("Snap ID could not be parsed")
+
 	return ""
 }

--- a/tests/end_to_end_test/snapshot_fail_test.go
+++ b/tests/end_to_end_test/snapshot_fail_test.go
@@ -82,6 +82,7 @@ func findASubDirFilePath(t *testing.T, parent string) string {
 	}
 
 	t.Fatalf("Could not find a subdirectory in parent dir %v", parent)
+
 	return ""
 }
 

--- a/tests/end_to_end_test/snapshot_fail_test.go
+++ b/tests/end_to_end_test/snapshot_fail_test.go
@@ -1,0 +1,140 @@
+package endtoend_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/kopia/kopia/tests/testenv"
+)
+
+func TestSnapshotFail(t *testing.T) {
+	t.Parallel()
+
+	e := testenv.NewCLITest(t)
+	defer e.Cleanup(t)
+	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
+
+	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
+	e.RunAndExpectSuccess(t, "policy", "set", "--global", "--keep-latest", strconv.Itoa(1<<31-1))
+
+	parentDirOfSource := makeScratchDir(t)
+	source := filepath.Join(parentDirOfSource, "source")
+
+	// Test snapshot of nonexistent directory fails
+	e.RunAndExpectFailure(t, "snapshot", "create", source)
+
+	testenv.MustCreateDirectoryTree(t, source, testenv.DirectoryTreeOptions{
+		Depth:                  2,
+		MaxSubdirsPerDirectory: 1,
+		MaxFilesPerDirectory:   1,
+	})
+
+	// Create snapshot
+	e.RunAndExpectSuccess(t, "snapshot", "create", source)
+
+	numSuccessfulSnapshots := 1
+
+	// Test the root dir permissions
+	for _, tc := range []struct {
+		desc      string
+		parentDir string
+	}{
+		{
+			desc:      "Modify permissions of the snapshot root directory",
+			parentDir: filepath.Dir(source),
+		},
+		{
+			desc:      "Modify permissions of entries in the snapshot root dir",
+			parentDir: source,
+		},
+		{
+			desc:      "Modify permissions of entries in a subdir of the snapshot root",
+			parentDir: findASubDirFilePath(t, source),
+		},
+	} {
+		t.Log(tc.desc)
+		numSuccessfulSnapshots += testPermissions(e, t, source, tc.parentDir)
+	}
+
+	// check the number of snapshots that succeeded match the length of
+	// a snap list output
+	si := e.ListSnapshotsAndExpectSuccess(t)
+	if got, want := len(si), 1; got != want {
+		t.Fatalf("got %v sources, wanted %v", got, want)
+	}
+
+	if got, want := len(si[0].Snapshots), numSuccessfulSnapshots; got != want {
+		t.Fatalf("got %v snapshots, wanted %v", got, want)
+	}
+}
+
+func findASubDirFilePath(t *testing.T, parent string) string {
+	fileInfoList, err := ioutil.ReadDir(parent)
+	testenv.AssertNoError(t, err)
+
+	for _, fi := range fileInfoList {
+		if fi.IsDir() {
+			return filepath.Join(parent, fi.Name())
+		}
+	}
+
+	t.Fatalf("Could not find a subdirectory in parent dir %v", parent)
+	return ""
+}
+
+// Perm constants
+const (
+	execOffset     = 0
+	readOffset     = 2
+	userPermOffset = 6
+)
+
+// testPermissions iterates over readable and executable permission states, testing
+// files and directories (if present). It issues the kopia snapshot command
+// against "source" and will test permissions against all entries in "parentDir".
+// It returns the number of successful snapshot operations.
+func testPermissions(e *testenv.CLITest, t *testing.T, source, parentDir string) int {
+	t.Helper()
+
+	fileList, err := ioutil.ReadDir(parentDir)
+	testenv.AssertNoError(t, err)
+
+	var numSuccessfulSnapshots int
+
+	for _, changeFile := range fileList {
+		// Iterate over all permission bit configurations
+		for _, readPermission := range []uint32{0, 1} {
+			for _, executePermission := range []uint32{0, 1} {
+				name := changeFile.Name()
+				mode := changeFile.Mode()
+				fp := filepath.Join(parentDir, name)
+				perm := readPermission<<readOffset | executePermission<<execOffset
+				chmod := os.FileMode(perm << userPermOffset)
+				t.Logf("Chmod: path: %s, isDir: %v, prevMode: %v, newMode: %v", fp, changeFile.IsDir(), mode, chmod)
+
+				err := os.Chmod(fp, chmod)
+				testenv.AssertNoError(t, err)
+
+				// Directory listing will fail if either the read or executed permissions are unset on the directory itself
+				if changeFile.IsDir() && readPermission&executePermission == 0 {
+					e.RunAndExpectFailure(t, "snapshot", "create", source)
+				} else {
+					// Currently by default, the uploader has IgnoreFileErrors set to true.
+					// Expect warning and successful snapshot creation
+					e.RunAndExpectSuccess(t, "snapshot", "create", source)
+					numSuccessfulSnapshots++
+				}
+
+				// Change permissions back and expect success
+				os.Chmod(fp, mode.Perm())
+				e.RunAndExpectSuccess(t, "snapshot", "create", source)
+				numSuccessfulSnapshots++
+			}
+		}
+	}
+
+	return numSuccessfulSnapshots
+}

--- a/tests/testenv/cli_test_env.go
+++ b/tests/testenv/cli_test_env.go
@@ -110,7 +110,7 @@ func (e *CLITest) Cleanup(t *testing.T) {
 func (e *CLITest) RunAndExpectSuccess(t *testing.T, args ...string) []string {
 	t.Helper()
 
-	stdout, err := e.Run(t, args...)
+	stdout, _, err := e.Run(t, args...)
 	if err != nil {
 		t.Fatalf("'kopia %v' failed with %v", strings.Join(args, " "), err)
 	}
@@ -118,11 +118,23 @@ func (e *CLITest) RunAndExpectSuccess(t *testing.T, args ...string) []string {
 	return stdout
 }
 
+// RunAndExpectSuccessWithErrOut runs the given command, expects it to succeed and returns its stdout and stderr lines.
+func (e *CLITest) RunAndExpectSuccessWithErrOut(t *testing.T, args ...string) ([]string, []string) {
+	t.Helper()
+
+	stdout, stderr, err := e.Run(t, args...)
+	if err != nil {
+		t.Fatalf("'kopia %v' failed with %v", strings.Join(args, " "), err)
+	}
+
+	return stdout, stderr
+}
+
 // RunAndExpectFailure runs the given command, expects it to fail and returns its output lines.
 func (e *CLITest) RunAndExpectFailure(t *testing.T, args ...string) []string {
 	t.Helper()
 
-	stdout, err := e.Run(t, args...)
+	stdout, _, err := e.Run(t, args...)
 	if err == nil {
 		t.Fatalf("'kopia %v' succeeded, but expected failure", strings.Join(args, " "))
 	}
@@ -143,7 +155,7 @@ func (e *CLITest) RunAndVerifyOutputLineCount(t *testing.T, wantLines int, args 
 }
 
 // Run executes kopia with given arguments and returns the output lines.
-func (e *CLITest) Run(t *testing.T, args ...string) ([]string, error) {
+func (e *CLITest) Run(t *testing.T, args ...string) ([]string, []string, error) {
 	t.Helper()
 	t.Logf("running 'kopia %v'", strings.Join(args, " "))
 	// nolint:gosec
@@ -175,7 +187,7 @@ func (e *CLITest) Run(t *testing.T, args ...string) ([]string, error) {
 	wg.Wait()
 	t.Logf("finished 'kopia %v' with err=%v and output:\n%v\nstderr:\n%v\n", strings.Join(args, " "), err, trimOutput(string(o)), trimOutput(string(stderr)))
 
-	return splitLines(string(o)), err
+	return splitLines(string(o)), splitLines(string(stderr)), err
 }
 
 func trimOutput(s string) string {
@@ -259,6 +271,23 @@ func CreateDirectoryTree(dirname string, options DirectoryTreeOptions, counters 
 	}
 
 	return createDirectoryTreeInternal(dirname, options, counters)
+}
+
+// MustCreateRandomFile creates a new file at the provided path with randomized contents.
+// It will fail with a test error if the creation does not succeed.
+func MustCreateRandomFile(t *testing.T, filepath string, options DirectoryTreeOptions, counters *DirectoryTreeCounters) {
+	if err := CreateRandomFile(filepath, options, counters); err != nil {
+		t.Error(err)
+	}
+}
+
+// CreateRandomFile creates a new file at the provided path with randomized contents
+func CreateRandomFile(filepath string, options DirectoryTreeOptions, counters *DirectoryTreeCounters) error {
+	if counters == nil {
+		counters = &DirectoryTreeCounters{}
+	}
+
+	return createRandomFile(filepath, options, counters)
 }
 
 // createDirectoryTreeInternal creates a directory tree of a given depth with random files.


### PR DESCRIPTION
Adding test to probe snapshot failure. Tests snapshot of non-existent source directory, and then iterates through file permissions for files, directories, and issues snapshot to the source. Permission combinations are applied to source dir, contents of source dir root, and contents of a subdirectory in that root.

Fixing kopia executable panic when a directory's contents can't be read. Previously the only Lstat error responded to was not-exist, letting other errors fall through and passing a nil `os.FileInfo` to the following function call, resulting in panic.