### PR TITLE
Scripts to measure resource utilization

### DIFF
--- a/examples/k8s-fio/fio-config/append-100m.fio
+++ b/examples/k8s-fio/fio-config/append-100m.fio
@@ -1,0 +1,7 @@
+[global]
+include global.fio
+[append-100m]
+directory=append-phase
+size=100m
+nrfiles=100
+file_append=1

--- a/examples/k8s-fio/fio-config/append-10g.fio
+++ b/examples/k8s-fio/fio-config/append-10g.fio
@@ -1,0 +1,7 @@
+[global]
+include global.fio
+[append-10g]
+#directory=append-phase
+size=10g
+nrfiles=1024
+file_append=1

--- a/examples/k8s-fio/fio-config/global.fio
+++ b/examples/k8s-fio/fio-config/global.fio
@@ -1,0 +1,12 @@
+; [global]]
+openfiles=10
+create_fsync=0
+create_serialize=1
+file_service_type=sequential
+ioengine=libaio
+direct=1
+iodepth=32
+blocksize=1m
+refill_buffers=1
+rw=write
+unique_filename=1

--- a/examples/k8s-fio/fio-config/write-100g.fio
+++ b/examples/k8s-fio/fio-config/write-100g.fio
@@ -1,0 +1,6 @@
+[global]
+include global.fio
+[write-100g]
+#directory=write-phase
+size=100g
+nrfiles=100000

--- a/examples/k8s-fio/fio-config/write-10g.fio
+++ b/examples/k8s-fio/fio-config/write-10g.fio
@@ -1,0 +1,6 @@
+[global]
+include global.fio
+[write-10g]
+#directory=write-phase
+size=10g
+nrfiles=10000

--- a/examples/k8s-fio/scripts/run-exp.sh
+++ b/examples/k8s-fio/scripts/run-exp.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env sh
+
+set -o errexit
+set -o nounset
+set -o xtrace
+
+TS=$(date +%Y%m%d-%H%M%S)
+
+OUTPUT_BASE=/data/exp-out
+OUTPUT_DIR="${OUTPUT_BASE}/${TS}"
+mkdir -p "${OUTPUT_DIR}"
+
+OUT_FILE_BASE=$(basename ${0})
+
+# Capture stdout and stderr
+exec 3>&1 4>&2
+exec 1>"${OUTPUT_DIR}/${OUT_FILE_BASE}-${TS}-out.txt" 2>"${OUTPUT_DIR}/${OUT_FILE_BASE}-${TS}-err.txt"
+
+export GOOGLE_APPLICATION_CREDENTIALS=/mnt/creds/kasten-gke-sa.json
+DATA_DIR=/data/fio
+KOPIA_PARALLEL=10
+CONFIG_DIR=/mnt/config
+PATH=${PATH}:/kopia
+
+# Capture the script and config parameters
+cp "${0}" "${OUTPUT_DIR}"
+cp "${CONFIG_DIR}"/* "${OUTPUT_DIR}"
+
+mkdir -p "${DATA_DIR}"
+
+KOPIA_LOG_DIR="${OUTPUT_BASE}/kopia-log"
+mkdir -p "${KOPIA_LOG_DIR}"
+
+# connect kopia to repo
+kopia repository connect from-config --token $(cat /mnt/creds/kopia-token)
+
+du -sh "${DATA_DIR}"
+# run data seed
+fio --output="${DATA_DIR}/output-${TS}-0-seed.json" --output-format=json+ ${CONFIG_DIR}/seed-100g.fio
+du -sh "${DATA_DIR}"
+
+# create initial snapshot and measure resource consumption
+/usr/bin/time -v kopia snapshot create "${DATA_DIR}" \
+    --log-level=error \
+    --log-dir="${KOPIA_LOG_DIR}" \
+    --parallel=${KOPIA_PARALLEL} \
+    --description="${TS} 0: Initial snapshot after seed"
+
+for i in $(seq 10)
+do
+    echo "Iteration ${i}"
+    # generate addtional data
+    fio --output="${DATA_DIR}/output-${TS}-${i}.json" --output-format=json+ ${CONFIG_DIR}/append-10g.fio
+    du -sh "${DATA_DIR}"
+    # create snapshot and measure resource consumption
+    /usr/bin/time -v kopia snapshot create "${DATA_DIR}" \
+        --log-level=error \
+        --log-dir="${KOPIA_LOG_DIR}" \
+        --parallel=${KOPIA_PARALLEL} \
+        --description="${TS} ${i}: Incremental snapshot"
+    # measure memory needed to load indices
+    /usr/bin/time -v kopia snapshot create "${DATA_DIR}" \
+        --log-level=error \
+        --log-dir="${KOPIA_LOG_DIR}" \
+        --parallel=${KOPIA_PARALLEL} \
+        --description="${TS} ${i}: Incremental snapshot 0 delta"
+done
+
+# Close output files
+exec 1>&- 2>&-
+# Restore stdout and stderr
+exec 1>&3 2>&4
+
+# Upload logs: Kopia FTW
+/usr/bin/time -v kopia snapshot create "${OUTPUT_BASE}" --description="${TS}: output"
+
+echo 'Done!'

--- a/examples/k8s-fio/scripts/run-prof.sh
+++ b/examples/k8s-fio/scripts/run-prof.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+#
+# Runs kopia operations with memory tracing and profiling enabled
+# Requires GNU time at /usr/bin/time
+
+set -o errexit
+set -o nounset
+set -o xtrace
+
+export GOOGLE_APPLICATION_CREDENTIALS=/mnt/creds/kasten-gke-sa.json
+
+readonly KOPIA_TOKEN=$(cat /mnt/creds/kopia-token)
+
+TS=$(date +%Y%m%d-%H%M%S)
+
+readonly OUTPUT_BASE=/data/exp-out
+readonly OUTPUT_DIR="${OUTPUT_BASE}/${TS}"
+mkdir -p "${OUTPUT_DIR}"
+
+readonly OUT_FILE_BASE=$(basename ${0})
+
+# Capture stdout and stderr
+exec 3>&1 4>&2
+exec 1>"${OUTPUT_DIR}/${OUT_FILE_BASE}-${TS}-out.txt" 2>"${OUTPUT_DIR}/${OUT_FILE_BASE}-${TS}-err.txt"
+
+readonly APPEND_FIO="append-10g.fio"
+readonly WRITE_FIO="write-10g.fio"
+readonly CONFIG_DIR=/mnt/config
+readonly DATA_DIR=/data/fio
+readonly KOPIA_LOG_DIR="${OUTPUT_BASE}/kopia-log"
+readonly KOPIA_PARALLEL=10
+readonly -a KOPIA_FLAGS=(
+#    --file-log-level=debug
+    --log-level=error
+    --log-dir="${KOPIA_LOG_DIR}"
+    --parallel=${KOPIA_PARALLEL}
+    --profile-memory=524288
+#    --track-memory-usage=30s
+)
+
+readonly -a TIME_FLAGS=(
+    --append
+    --output="${OUTPUT_DIR}/kopia-time.txt"
+    --verbose
+)
+
+PATH=${PATH}:/kopia
+
+# Capture the script and config parameters
+cp "${0}" "${OUTPUT_DIR}"
+cp "${CONFIG_DIR}"/* "${OUTPUT_DIR}"
+
+ulimit -a
+
+mkdir -p "${DATA_DIR}" "${KOPIA_LOG_DIR}"
+
+# connect kopia to repo
+/usr/bin/time "${TIME_FLAGS[@]}" \
+    kopia repository connect from-config --token "${KOPIA_TOKEN}"
+
+du -sh "${DATA_DIR}"
+mkdir -p "${DATA_DIR}/${TS}"
+cd "${DATA_DIR}/${TS}"
+# Generate initial data
+fio --output="${DATA_DIR}/output-${TS}-0-seed.json" --output-format=json+ --directory="${DATA_DIR}/${TS}/write-phase" "${CONFIG_DIR}/${WRITE_FIO}"
+du -sh "${DATA_DIR}"
+
+# create initial snapshot and measure resource consumption
+/usr/bin/time "${TIME_FLAGS[@]}" \
+    kopia snapshot create "${DATA_DIR}" \
+    "${KOPIA_FLAGS[@]}" \
+    --profile-dir="${OUTPUT_DIR}/prof/0" \
+    --description="${TS} 0: Initial snapshot after seed"
+
+#if false ; then
+
+for i in $(seq 10)
+do
+    echo "Iteration ${i}"
+    mkdir -p "${DATA_DIR}/${TS}/${i}"
+    cd "${DATA_DIR}/${TS}/${i}"
+    # generate addtional data
+    fio --output="${DATA_DIR}/output-${TS}-${i}.json" --output-format=json+ "${CONFIG_DIR}/${APPEND_FIO}"
+    du -sh "${DATA_DIR}"
+    # create snapshot and measure resource consumption
+    /usr/bin/time "${TIME_FLAGS[@]}" \
+        kopia snapshot create "${DATA_DIR}" \
+        "${KOPIA_FLAGS[@]}" \
+        --profile-dir="${OUTPUT_DIR}/prof/${i}" \
+        --description="${TS} ${i}: Incremental snapshot"
+    # measure memory needed to load indices and perform a tree walk
+    /usr/bin/time "${TIME_FLAGS[@]}" \
+        kopia snapshot create "${DATA_DIR}" \
+        "${KOPIA_FLAGS[@]}" \
+        --profile-dir="${OUTPUT_DIR}/prof/${i}-d0" \
+        --description="${TS} ${i}: Incremental snapshot 0 delta"
+done
+
+#fi
+
+# Close output files
+exec 1>&- 2>&-
+# Restore stdout and stderr
+exec 1>&3 2>&4
+
+# Upload logs, profile and output files: Kopia FTW
+/usr/bin/time --verbose kopia snapshot create "${OUTPUT_BASE}" --description="${TS}: output"
+
+echo 'Done!'


### PR DESCRIPTION
There are a few implicit assumptions about the directory layout used in the scripts.
See the shell variable definitions in `run.sh` and `run-prof.sh`.

The `fio` parameters were chosen with the goal of:
* generating as much unique data as possible, to force `kopia` to accumulate state, buffer data and create new blobs.
* speeding up the data generation, but this was not done in a systematic manner, and depending on the underlying resources, other parameter choices may result in higher data generation throughputs.

