### PR TITLE
Adding library for file generation using 'fio'

### DIFF
--- a/tests/tools/fio/config.go
+++ b/tests/tools/fio/config.go
@@ -1,12 +1,17 @@
 package fio
 
+import "strings"
+
 // Config structures the fields of a FIO job run configuration
 type Config []Job
 
+// String implements the stringer interface, formats the Config
+// as it would appear in a well-formed fio config file.
 func (cfg Config) String() string {
-	ret := ""
+	ret := []string{}
 	for _, job := range cfg {
-		ret += job.String()
+		ret = append(ret, job.String())
 	}
-	return ret
+
+	return strings.Join(ret, "\n")
 }

--- a/tests/tools/fio/config.go
+++ b/tests/tools/fio/config.go
@@ -2,3 +2,11 @@ package fio
 
 // Config structures the fields of a FIO job run configuration
 type Config []Job
+
+func (cfg Config) String() string {
+	ret := ""
+	for _, job := range cfg {
+		ret += job.String()
+	}
+	return ret
+}

--- a/tests/tools/fio/config.go
+++ b/tests/tools/fio/config.go
@@ -1,0 +1,4 @@
+package fio
+
+// Config structures the fields of a FIO job run configuration
+type Config []Job

--- a/tests/tools/fio/fio.go
+++ b/tests/tools/fio/fio.go
@@ -69,7 +69,10 @@ func (fr *Runner) Cleanup() {
 func (fr *Runner) RunConfigs(cfgs ...Config) (stdout, stderr string, err error) {
 	var args []string
 
+	// Apply global config before any other configs
 	for _, cfg := range append(append([]Config{}, fr.Global), cfgs...) {
+
+		log.Printf("Applying config:\n%s", cfg)
 
 		for _, job := range cfg {
 

--- a/tests/tools/fio/fio.go
+++ b/tests/tools/fio/fio.go
@@ -1,0 +1,120 @@
+package fio
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+)
+
+// List of fio flags
+const (
+	JobNameFlag = "--name"
+)
+
+// Runner is a helper for running fio commands
+type Runner struct {
+	Exe     string
+	DataDir string
+	Global  Config
+}
+
+// NewRunner creates a new fio runner
+func NewRunner() (*Runner, error) {
+	Exe := os.Getenv("FIO_EXE")
+	if Exe == "" {
+		Exe = "fio"
+	}
+
+	dataDir, err := ioutil.TempDir("", "fio-data")
+	if err != nil {
+		return nil, err
+	}
+
+	return &Runner{
+		Exe:     Exe,
+		DataDir: dataDir,
+		Global: Config{
+			{
+				Name: "global",
+				Options: map[string]string{
+					"openfiles":         "10",
+					"create_fsync":      "0",
+					"create_serialize":  "1",
+					"file_service_type": "sequential",
+					"ioengine":          "libaio",
+					"direct":            "1",
+					"iodepth":           "32",
+					"blocksize":         "1m",
+					"refill_buffers":    "",
+					"rw":                "write",
+					"unique_filename":   "1",
+					"directory":         dataDir,
+				},
+			},
+		},
+	}, nil
+}
+
+// Cleanup cleans up the data directory
+func (fr *Runner) Cleanup() {
+	if fr.DataDir != "" {
+		os.RemoveAll(fr.DataDir) //nolint:errcheck
+	}
+}
+
+// RunConfigs runs fio using the provided Configs
+func (fr *Runner) RunConfigs(cfgs ...Config) (stdout, stderr string, err error) {
+	var args []string
+
+	for _, cfg := range append(append([]Config{}, fr.Global), cfgs...) {
+
+		for _, job := range cfg {
+
+			args = append(args, JobNameFlag, job.Name)
+			for flagK, flagV := range job.Options {
+				args = append(args, "--"+flagK)
+
+				if flagV != "" {
+					args = append(args, flagV)
+				}
+			}
+		}
+	}
+
+	return fr.Run(args...)
+}
+
+// Run will execute the fio command with the given args
+func (fr *Runner) Run(args ...string) (stdout, stderr string, err error) {
+	argsStr := strings.Join(args, " ")
+	log.Printf("running '%s %v'", fr.Exe, argsStr)
+	c := exec.Command(fr.Exe, args...)
+
+	stderrPipe, err := c.StderrPipe()
+	if err != nil {
+		return stdout, stderr, err
+	}
+
+	var errOut []byte
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+
+		errOut, err = ioutil.ReadAll(stderrPipe)
+	}()
+
+	o, err := c.Output()
+
+	wg.Wait()
+
+	log.Printf("finished '%s %v' with err=%v and output:\n%v\n%v", fr.Exe, argsStr, err, string(o), string(errOut))
+
+	return string(o), string(errOut), err
+}

--- a/tests/tools/fio/fio.go
+++ b/tests/tools/fio/fio.go
@@ -74,7 +74,7 @@ func (fr *Runner) RunConfigs(cfgs ...Config) (stdout, stderr string, err error) 
 	var args []string
 
 	// Apply global config before any other configs
-	for _, cfg := range append(append([]Config{}, fr.Global), cfgs...) {
+	for _, cfg := range append([]Config{fr.Global}, cfgs...) {
 		log.Printf("Applying config:\n%s", cfg)
 
 		for _, job := range cfg {

--- a/tests/tools/fio/fio.go
+++ b/tests/tools/fio/fio.go
@@ -1,3 +1,7 @@
+// Package fio wraps calls to the fio tool.
+// It assumes the tool is executable by "fio", but
+// gives the option to specify another executable
+// path by setting environment variable FIO_EXE.
 package fio
 
 import (
@@ -71,11 +75,9 @@ func (fr *Runner) RunConfigs(cfgs ...Config) (stdout, stderr string, err error) 
 
 	// Apply global config before any other configs
 	for _, cfg := range append(append([]Config{}, fr.Global), cfgs...) {
-
 		log.Printf("Applying config:\n%s", cfg)
 
 		for _, job := range cfg {
-
 			args = append(args, JobNameFlag, job.Name)
 			for flagK, flagV := range job.Options {
 				args = append(args, "--"+flagK)
@@ -94,6 +96,7 @@ func (fr *Runner) RunConfigs(cfgs ...Config) (stdout, stderr string, err error) 
 func (fr *Runner) Run(args ...string) (stdout, stderr string, err error) {
 	argsStr := strings.Join(args, " ")
 	log.Printf("running '%s %v'", fr.Exe, argsStr)
+	// nolint:gosec
 	c := exec.Command(fr.Exe, args...)
 
 	stderrPipe, err := c.StderrPipe()

--- a/tests/tools/fio/fio_test.go
+++ b/tests/tools/fio/fio_test.go
@@ -1,0 +1,59 @@
+package fio
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/kopia/kopia/tests/testenv"
+)
+
+func TestFIORun(t *testing.T) {
+	r, err := NewRunner()
+	testenv.AssertNoError(t, err)
+	defer r.Cleanup()
+
+	stdout, stderr, err := r.Run()
+	testenv.AssertNoError(t, err)
+
+	fmt.Println(stdout)
+	fmt.Println("ERR", stderr)
+}
+
+func TestFIORunConfig(t *testing.T) {
+	r, err := NewRunner()
+	testenv.AssertNoError(t, err)
+	defer r.Cleanup()
+
+	cfgs := []Config{
+		{
+			{
+				Name: "global",
+				Options: map[string]string{
+					"openfiles":         "10",
+					"create_fsync":      "0",
+					"create_serialize":  "1",
+					"file_service_type": "sequential",
+					"ioengine":          "libaio",
+					"direct":            "1",
+					"iodepth":           "32",
+					"blocksize":         "1m",
+					"refill_buffers":    "",
+					"rw":                "write",
+					"unique_filename":   "1",
+				},
+			},
+			{
+				Name: "write-10g",
+				Options: map[string]string{
+					"size":    "1g",
+					"nrfiles": "10",
+				},
+			},
+		},
+	}
+	stdout, stderr, err := r.RunConfigs(cfgs...)
+	testenv.AssertNoError(t, err)
+
+	fmt.Println(stdout)
+	fmt.Println("STDERR", stderr)
+}

--- a/tests/tools/fio/fio_test.go
+++ b/tests/tools/fio/fio_test.go
@@ -10,6 +10,7 @@ import (
 func TestFIORun(t *testing.T) {
 	r, err := NewRunner()
 	testenv.AssertNoError(t, err)
+
 	defer r.Cleanup()
 
 	stdout, stderr, err := r.Run()
@@ -30,6 +31,7 @@ func TestFIORun(t *testing.T) {
 func TestFIORunConfig(t *testing.T) {
 	r, err := NewRunner()
 	testenv.AssertNoError(t, err)
+
 	defer r.Cleanup()
 
 	cfg := Config{
@@ -44,7 +46,7 @@ func TestFIORunConfig(t *testing.T) {
 	stdout, stderr, err := r.RunConfigs(cfg)
 	testenv.AssertNoError(t, err)
 
-	if len(stderr) != 0 {
+	if stderr != "" {
 		t.Error("Stderr was not empty")
 	}
 
@@ -56,6 +58,7 @@ func TestFIORunConfig(t *testing.T) {
 func TestFIOGlobalConfigOverride(t *testing.T) {
 	r, err := NewRunner()
 	testenv.AssertNoError(t, err)
+
 	defer r.Cleanup()
 
 	cfgs := []Config{

--- a/tests/tools/fio/fio_test.go
+++ b/tests/tools/fio/fio_test.go
@@ -1,7 +1,6 @@
 package fio
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
@@ -14,9 +13,18 @@ func TestFIORun(t *testing.T) {
 	defer r.Cleanup()
 
 	stdout, stderr, err := r.Run()
-	fmt.Println(stdout)
-	fmt.Println(stderr)
-	fmt.Println(err)
+	if err == nil {
+		t.Fatal("Expected error to be set as no params were passed")
+	}
+
+	if !strings.Contains(stderr, "No job(s) defined") {
+		t.Fatal("Expected an error indicating no jobs were defined")
+	}
+
+	if !strings.Contains(stdout, "Print this page") {
+		// Indicates the --help page has been printed
+		t.Fatal("Expected --help page when running fio with no args")
+	}
 }
 
 func TestFIORunConfig(t *testing.T) {
@@ -36,8 +44,13 @@ func TestFIORunConfig(t *testing.T) {
 	stdout, stderr, err := r.RunConfigs(cfg)
 	testenv.AssertNoError(t, err)
 
-	fmt.Println(stdout)
-	fmt.Println("STDERR", stderr)
+	if len(stderr) != 0 {
+		t.Error("Stderr was not empty")
+	}
+
+	if !strings.Contains(stdout, "rw=write") {
+		t.Error("Expected the output to indicate writes took place")
+	}
 }
 
 func TestFIOGlobalConfigOverride(t *testing.T) {

--- a/tests/tools/fio/job.go
+++ b/tests/tools/fio/job.go
@@ -15,11 +15,13 @@ type Job struct {
 // as it would appear in a well-formed fio config file.
 func (job Job) String() string {
 	ret := []string{fmt.Sprintf("[%s]", job.Name)}
+
 	for k, v := range job.Options {
 		if v == "" {
 			ret = append(ret, k)
 			continue
 		}
+
 		ret = append(ret, fmt.Sprintf("%s=%s", k, v))
 	}
 

--- a/tests/tools/fio/job.go
+++ b/tests/tools/fio/job.go
@@ -11,6 +11,8 @@ type Job struct {
 	Options Options
 }
 
+// String implements the stringer interface, formats the Job
+// as it would appear in a well-formed fio config file.
 func (job Job) String() string {
 	ret := []string{fmt.Sprintf("[%s]", job.Name)}
 	for k, v := range job.Options {

--- a/tests/tools/fio/job.go
+++ b/tests/tools/fio/job.go
@@ -1,0 +1,7 @@
+package fio
+
+// Job represents the configuration for running a FIO job
+type Job struct {
+	Name    string
+	Options map[string]string
+}

--- a/tests/tools/fio/job.go
+++ b/tests/tools/fio/job.go
@@ -1,7 +1,25 @@
 package fio
 
+import (
+	"fmt"
+	"strings"
+)
+
 // Job represents the configuration for running a FIO job
 type Job struct {
 	Name    string
-	Options map[string]string
+	Options Options
+}
+
+func (job Job) String() string {
+	ret := []string{fmt.Sprintf("[%s]", job.Name)}
+	for k, v := range job.Options {
+		if v == "" {
+			ret = append(ret, k)
+			continue
+		}
+		ret = append(ret, fmt.Sprintf("%s=%s", k, v))
+	}
+
+	return strings.Join(ret, "\n")
 }

--- a/tests/tools/fio/main_test.go
+++ b/tests/tools/fio/main_test.go
@@ -1,0 +1,19 @@
+package fio
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	Exe := os.Getenv("FIO_EXE")
+	if Exe == "" {
+		fmt.Println("Skipping fio tests if FIO_EXE is not set")
+		os.Exit(0)
+	}
+
+	result := m.Run()
+
+	os.Exit(result)
+}

--- a/tests/tools/fio/options.go
+++ b/tests/tools/fio/options.go
@@ -5,14 +5,14 @@ type Options map[string]string
 
 // Merge will merge two Options, overwriting common option keys
 // with the incoming option values. Returns the merged result
-func (opt Options) Merge(otherOpt Options) map[string]string {
-	out := make(map[string]string)
+func (o Options) Merge(other Options) map[string]string {
+	out := make(map[string]string, len(o)+len(other))
 
-	for k, v := range opt {
+	for k, v := range o {
 		out[k] = v
 	}
 
-	for k, v := range otherOpt {
+	for k, v := range other {
 		out[k] = v
 	}
 

--- a/tests/tools/fio/options.go
+++ b/tests/tools/fio/options.go
@@ -1,0 +1,13 @@
+package fio
+
+// Options are flags to be set when running fio
+type Options map[string]string
+
+// Merge will merge two Options, overwriting common option keys
+// with the incoming option values. Returns the merged result
+func (opt Options) Merge(otherOpt Options) map[string]string {
+	for k, v := range otherOpt {
+		opt[k] = v
+	}
+	return opt
+}

--- a/tests/tools/fio/options.go
+++ b/tests/tools/fio/options.go
@@ -9,5 +9,6 @@ func (opt Options) Merge(otherOpt Options) map[string]string {
 	for k, v := range otherOpt {
 		opt[k] = v
 	}
+
 	return opt
 }

--- a/tests/tools/fio/options.go
+++ b/tests/tools/fio/options.go
@@ -6,9 +6,15 @@ type Options map[string]string
 // Merge will merge two Options, overwriting common option keys
 // with the incoming option values. Returns the merged result
 func (opt Options) Merge(otherOpt Options) map[string]string {
-	for k, v := range otherOpt {
-		opt[k] = v
+	out := make(map[string]string)
+
+	for k, v := range opt {
+		out[k] = v
 	}
 
-	return opt
+	for k, v := range otherOpt {
+		out[k] = v
+	}
+
+	return out
 }

--- a/tests/tools/fio/workload.go
+++ b/tests/tools/fio/workload.go
@@ -1,0 +1,32 @@
+package fio
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+)
+
+// WriteFiles writes files to the directory specified by path, up to the
+// provided size and number of files
+func (fr *Runner) WriteFiles(path string, sizeB int64, numFiles int) error {
+	fullPath := filepath.Join(fr.DataDir, path)
+
+	err := os.MkdirAll(fullPath, 0777)
+	if err != nil {
+		return err
+	}
+
+	_, _, err = fr.RunConfigs(Config{
+		{
+			Name: fmt.Sprintf("write-%vB-%v", sizeB, numFiles),
+			Options: map[string]string{
+				"size":      strconv.Itoa(int(sizeB)),
+				"nrfiles":   strconv.Itoa(numFiles),
+				"directory": fullPath,
+			},
+		},
+	})
+
+	return err
+}

--- a/tests/tools/fio/workload.go
+++ b/tests/tools/fio/workload.go
@@ -12,7 +12,7 @@ import (
 func (fr *Runner) WriteFiles(path string, sizeB int64, numFiles int, opt Options) error {
 	fullPath := filepath.Join(fr.DataDir, path)
 
-	err := os.MkdirAll(fullPath, 0777)
+	err := os.MkdirAll(fullPath, 0700)
 	if err != nil {
 		return err
 	}

--- a/tests/tools/fio/workload.go
+++ b/tests/tools/fio/workload.go
@@ -9,7 +9,7 @@ import (
 
 // WriteFiles writes files to the directory specified by path, up to the
 // provided size and number of files
-func (fr *Runner) WriteFiles(path string, sizeB int64, numFiles int) error {
+func (fr *Runner) WriteFiles(path string, sizeB int64, numFiles int, opt Options) error {
 	fullPath := filepath.Join(fr.DataDir, path)
 
 	err := os.MkdirAll(fullPath, 0777)
@@ -20,11 +20,11 @@ func (fr *Runner) WriteFiles(path string, sizeB int64, numFiles int) error {
 	_, _, err = fr.RunConfigs(Config{
 		{
 			Name: fmt.Sprintf("write-%vB-%v", sizeB, numFiles),
-			Options: map[string]string{
+			Options: opt.Merge(Options{
 				"size":      strconv.Itoa(int(sizeB)),
 				"nrfiles":   strconv.Itoa(numFiles),
 				"directory": fullPath,
-			},
+			}),
 		},
 	})
 

--- a/tests/tools/fio/workload_test.go
+++ b/tests/tools/fio/workload_test.go
@@ -12,6 +12,7 @@ import (
 func TestWriteFiles(t *testing.T) {
 	r, err := NewRunner()
 	testenv.AssertNoError(t, err)
+
 	defer r.Cleanup()
 
 	relativeWritePath := "some/path/to/check"
@@ -24,6 +25,7 @@ func TestWriteFiles(t *testing.T) {
 
 	fullPath := filepath.Join(r.DataDir, relativeWritePath)
 	dir, err := ioutil.ReadDir(fullPath)
+	testenv.AssertNoError(t, err)
 
 	if got, want := len(dir), numFiles; got != want {
 		t.Errorf("Did not get expected number of files %v (actual) != %v (expected", got, want)
@@ -31,6 +33,7 @@ func TestWriteFiles(t *testing.T) {
 
 	sizeTot := int64(0)
 	sizeExp := int64(0)
+
 	for _, fi := range dir {
 		fmt.Println(fi.Name(), fi.Size())
 		sizeTot += fi.Size()

--- a/tests/tools/fio/workload_test.go
+++ b/tests/tools/fio/workload_test.go
@@ -19,7 +19,7 @@ func TestWriteFiles(t *testing.T) {
 	numFiles := 13
 
 	// Test a call to WriteFiles
-	err = r.WriteFiles(relativeWritePath, writeSizeB, numFiles)
+	err = r.WriteFiles(relativeWritePath, writeSizeB, numFiles, Options{})
 	testenv.AssertNoError(t, err)
 
 	fullPath := filepath.Join(r.DataDir, relativeWritePath)

--- a/tests/tools/fio/workload_test.go
+++ b/tests/tools/fio/workload_test.go
@@ -1,0 +1,46 @@
+package fio
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/kopia/kopia/tests/testenv"
+)
+
+func TestWriteFiles(t *testing.T) {
+	r, err := NewRunner()
+	testenv.AssertNoError(t, err)
+	defer r.Cleanup()
+
+	relativeWritePath := "some/path/to/check"
+	writeSizeB := int64(7 * 1024 * 1024 * 1024) // 7 GiB
+	numFiles := 13
+
+	// Test a call to WriteFiles
+	err = r.WriteFiles(relativeWritePath, writeSizeB, numFiles)
+	testenv.AssertNoError(t, err)
+
+	fullPath := filepath.Join(r.DataDir, relativeWritePath)
+	dir, err := ioutil.ReadDir(fullPath)
+
+	if got, want := len(dir), numFiles; got != want {
+		t.Errorf("Did not get expected number of files %v (actual) != %v (expected", got, want)
+	}
+
+	sizeTot := int64(0)
+	sizeExp := int64(0)
+	for _, fi := range dir {
+		fmt.Println(fi.Name(), fi.Size())
+		sizeTot += fi.Size()
+
+		// Calculate the expected size taking into account the rounding error
+		// introduced by dividing the requested write size across the number of files
+		sizeExp += writeSizeB / int64(numFiles)
+	}
+
+	if got, want := sizeTot, sizeExp; got != want {
+		t.Errorf("Did not get the expected amount of data written %v (actual) != %v (expected)", got, want)
+	}
+}

--- a/tests/tools/fio/workload_test.go
+++ b/tests/tools/fio/workload_test.go
@@ -15,7 +15,7 @@ func TestWriteFiles(t *testing.T) {
 	defer r.Cleanup()
 
 	relativeWritePath := "some/path/to/check"
-	writeSizeB := int64(7 * 1024 * 1024 * 1024) // 7 GiB
+	writeSizeB := int64(3 * 1024 * 1024 * 1024) // 3 GiB
 	numFiles := 13
 
 	// Test a call to WriteFiles

--- a/tests/tools/fio/workload_test.go
+++ b/tests/tools/fio/workload_test.go
@@ -16,7 +16,7 @@ func TestWriteFiles(t *testing.T) {
 	defer r.Cleanup()
 
 	relativeWritePath := "some/path/to/check"
-	writeSizeB := int64(3 * 1024 * 1024 * 1024) // 3 GiB
+	writeSizeB := int64(256 * 1024 * 1024) // 256 MiB
 	numFiles := 13
 
 	// Test a call to WriteFiles
@@ -32,18 +32,14 @@ func TestWriteFiles(t *testing.T) {
 	}
 
 	sizeTot := int64(0)
-	sizeExp := int64(0)
 
 	for _, fi := range dir {
 		fmt.Println(fi.Name(), fi.Size())
 		sizeTot += fi.Size()
-
-		// Calculate the expected size taking into account the rounding error
-		// introduced by dividing the requested write size across the number of files
-		sizeExp += writeSizeB / int64(numFiles)
 	}
 
-	if got, want := sizeTot, sizeExp; got != want {
+	want := (writeSizeB / int64(numFiles)) * int64(numFiles)
+	if got := sizeTot; got != want {
 		t.Errorf("Did not get the expected amount of data written %v (actual) != %v (expected)", got, want)
 	}
 }


### PR DESCRIPTION
Adding a helper library that wraps `fio` execution. This is the basic initial check-in that implements the runners, configs, and a single WriteFiles helper. It should be enough to unblock subsequent tasks that will use fio to generate data sets for kopia snapshot verification. Further helpers can be added as needed.

Addresses K10-3352