### PR TITLE
Add flags to set policy err handling

### DIFF
--- a/cli/command_policy_set.go
+++ b/cli/command_policy_set.go
@@ -50,11 +50,15 @@ var (
 	policySetRemoveNeverCompress = policySetCommand.Flag("remove-never-compress", "List of extensions to remove from the never compress list").PlaceHolder("PATTERN").Strings()
 	policySetClearNeverCompress  = policySetCommand.Flag("clear-never-compress", "Clear list of extensions in the never compress list").Bool()
 
-	// Dot-ignore iles to look at.
+	// Dot-ignore files to look at.
 	policySetAddDotIgnore    = policySetCommand.Flag("add-dot-ignore", "List of paths to add to the dot-ignore list").PlaceHolder("FILENAME").Strings()
 	policySetRemoveDotIgnore = policySetCommand.Flag("remove-dot-ignore", "List of paths to remove from the dot-ignore list").PlaceHolder("FILENAME").Strings()
 	policySetClearDotIgnore  = policySetCommand.Flag("clear-dot-ignore", "Clear list of paths in the dot-ignore list").Bool()
 	policySetMaxFileSize     = policySetCommand.Flag("max-file-size", "Exclude files above given size").PlaceHolder("N").String()
+
+	// Error handling behavior.
+	policyIgnoreFileErrors      = policySetCommand.Flag("ignore-file-errors", "Ignore errors reading files while traversing ('true', 'false', 'inherit").String()
+	policyIgnoreDirectoryErrors = policySetCommand.Flag("ignore-dir-errors", "Ignore errors reading directories while traversing ('true', 'false', 'inherit").String()
 
 	// General policy.
 	policySetInherit = policySetCommand.Flag(inheritPolicyString, "Enable or disable inheriting policies from the parent").BoolList()
@@ -107,6 +111,10 @@ func setPolicyFromFlags(p *policy.Policy, changeCount *int) error {
 
 	setFilesPolicyFromFlags(&p.FilesPolicy, changeCount)
 
+	if err := setErrorHandlingPolicyFromFlags(&p.ErrorHandlingPolicy, changeCount); err != nil {
+		return errors.Wrap(err, "error handling policy")
+	}
+
 	if err := setCompressionPolicyFromFlags(&p.CompressionPolicy, changeCount); err != nil {
 		return errors.Wrap(err, "compression policy")
 	}
@@ -149,6 +157,54 @@ func setFilesPolicyFromFlags(fp *policy.FilesPolicy, changeCount *int) {
 	} else {
 		fp.IgnoreRules = addRemoveDedupeAndSort("ignored files", fp.IgnoreRules, *policySetAddIgnore, *policySetRemoveIgnore, changeCount)
 	}
+}
+
+func setErrorHandlingPolicyFromFlags(fp *policy.ErrorHandlingPolicy, changeCount *int) error {
+	switch {
+	case *policyIgnoreFileErrors == "":
+	case *policyIgnoreFileErrors == inheritPolicyString:
+		*changeCount++
+
+		fp.IgnoreFileErrorsSet = false
+
+		printStderr(" - inherit file read error behavior from parent\n")
+	default:
+		val, err := strconv.ParseBool(*policyIgnoreFileErrors)
+		if err != nil {
+			return err
+		}
+
+		*changeCount++
+
+		fp.IgnoreFileErrors = val
+		fp.IgnoreFileErrorsSet = true
+
+		printStderr(" - setting ignore file read errors to %v\n", val)
+	}
+
+	switch {
+	case *policyIgnoreDirectoryErrors == "":
+	case *policyIgnoreDirectoryErrors == inheritPolicyString:
+		*changeCount++
+
+		fp.IgnoreDirectoryErrorsSet = false
+
+		printStderr(" - inherit directory read error behavior from parent\n")
+	default:
+		val, err := strconv.ParseBool(*policyIgnoreDirectoryErrors)
+		if err != nil {
+			return err
+		}
+
+		*changeCount++
+
+		fp.IgnoreDirectoryErrors = val
+		fp.IgnoreDirectoryErrorsSet = true
+
+		printStderr(" - setting ignore directory read errors to %v\n", val)
+	}
+
+	return nil
 }
 
 func setRetentionPolicyFromFlags(rp *policy.RetentionPolicy, changeCount *int) error {

--- a/cli/command_policy_set_test.go
+++ b/cli/command_policy_set_test.go
@@ -120,6 +120,74 @@ func TestSetErrorHandlingPolicyFromFlags(t *testing.T) {
 			expErr:         false,
 			expChangeCount: 2,
 		},
+		{
+			name: "File false, dir true",
+			startingPolicy: &policy.ErrorHandlingPolicy{
+				IgnoreFileErrors:      true,
+				IgnoreDirectoryErrors: true,
+			},
+			fileArg: "false",
+			dirArg:  "true",
+			expResult: &policy.ErrorHandlingPolicy{
+				IgnoreFileErrors:         false,
+				IgnoreFileErrorsSet:      true,
+				IgnoreDirectoryErrors:    true,
+				IgnoreDirectoryErrorsSet: true,
+			},
+			expErr:         false,
+			expChangeCount: 2,
+		},
+		{
+			name: "File true, dir false",
+			startingPolicy: &policy.ErrorHandlingPolicy{
+				IgnoreFileErrors:      true,
+				IgnoreDirectoryErrors: true,
+			},
+			fileArg: "true",
+			dirArg:  "false",
+			expResult: &policy.ErrorHandlingPolicy{
+				IgnoreFileErrors:         true,
+				IgnoreFileErrorsSet:      true,
+				IgnoreDirectoryErrors:    false,
+				IgnoreDirectoryErrorsSet: true,
+			},
+			expErr:         false,
+			expChangeCount: 2,
+		},
+		{
+			name: "File inherit, dir true",
+			startingPolicy: &policy.ErrorHandlingPolicy{
+				IgnoreFileErrors:      true,
+				IgnoreDirectoryErrors: true,
+			},
+			fileArg: "inherit",
+			dirArg:  "true",
+			expResult: &policy.ErrorHandlingPolicy{
+				IgnoreFileErrors:         true,
+				IgnoreFileErrorsSet:      false,
+				IgnoreDirectoryErrors:    true,
+				IgnoreDirectoryErrorsSet: true,
+			},
+			expErr:         false,
+			expChangeCount: 2,
+		},
+		{
+			name: "File true, dir inherit",
+			startingPolicy: &policy.ErrorHandlingPolicy{
+				IgnoreFileErrors:      true,
+				IgnoreDirectoryErrors: true,
+			},
+			fileArg: "true",
+			dirArg:  "inherit",
+			expResult: &policy.ErrorHandlingPolicy{
+				IgnoreFileErrors:         true,
+				IgnoreFileErrorsSet:      true,
+				IgnoreDirectoryErrors:    true,
+				IgnoreDirectoryErrorsSet: false,
+			},
+			expErr:         false,
+			expChangeCount: 2,
+		},
 	} {
 		t.Log(tc.name)
 

--- a/cli/command_policy_set_test.go
+++ b/cli/command_policy_set_test.go
@@ -8,9 +8,9 @@ import (
 )
 
 func TestSetErrorHandlingPolicyFromFlags(t *testing.T) {
-
 	initialFileFlagVal := *policyIgnoreFileErrors
 	initialDirFlagVal := *policyIgnoreDirectoryErrors
+
 	defer func() {
 		*policyIgnoreFileErrors = initialFileFlagVal
 		*policyIgnoreDirectoryErrors = initialDirFlagVal

--- a/cli/command_policy_set_test.go
+++ b/cli/command_policy_set_test.go
@@ -1,0 +1,137 @@
+package cli
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/kopia/kopia/snapshot/policy"
+)
+
+func TestSetErrorHandlingPolicyFromFlags(t *testing.T) {
+
+	initialFileFlagVal := *policyIgnoreFileErrors
+	initialDirFlagVal := *policyIgnoreDirectoryErrors
+	defer func() {
+		*policyIgnoreFileErrors = initialFileFlagVal
+		*policyIgnoreDirectoryErrors = initialDirFlagVal
+	}()
+
+	for _, tc := range []struct {
+		name           string
+		startingPolicy *policy.ErrorHandlingPolicy
+		fileArg        string
+		dirArg         string
+		expResult      *policy.ErrorHandlingPolicy
+		expErr         bool
+		expChangeCount int
+	}{
+		{
+			name: "No values provided as command line arguments",
+			startingPolicy: &policy.ErrorHandlingPolicy{
+				IgnoreFileErrors:         true,
+				IgnoreFileErrorsSet:      true,
+				IgnoreDirectoryErrors:    true,
+				IgnoreDirectoryErrorsSet: true,
+			},
+			fileArg: "",
+			dirArg:  "",
+			expResult: &policy.ErrorHandlingPolicy{
+				IgnoreFileErrors:         true,
+				IgnoreFileErrorsSet:      true,
+				IgnoreDirectoryErrors:    true,
+				IgnoreDirectoryErrorsSet: true,
+			},
+			expErr:         false,
+			expChangeCount: 0,
+		},
+		{
+			name:           "Malformed arguments",
+			startingPolicy: &policy.ErrorHandlingPolicy{},
+			fileArg:        "not-true-or-false",
+			dirArg:         "not-even-inherit",
+			expResult: &policy.ErrorHandlingPolicy{
+				IgnoreFileErrors:         false,
+				IgnoreFileErrorsSet:      false,
+				IgnoreDirectoryErrors:    false,
+				IgnoreDirectoryErrorsSet: false,
+			},
+			expErr:         true,
+			expChangeCount: 0,
+		},
+		{
+			name:           "One is malformed, the other well formed",
+			startingPolicy: &policy.ErrorHandlingPolicy{},
+			fileArg:        "true",
+			dirArg:         "some-malformed-arg",
+			expResult: &policy.ErrorHandlingPolicy{
+				IgnoreFileErrors:         true,
+				IgnoreFileErrorsSet:      true,
+				IgnoreDirectoryErrors:    false,
+				IgnoreDirectoryErrorsSet: false,
+			},
+			expErr:         true,
+			expChangeCount: 1,
+		},
+		{
+			name: "Inherit case",
+			startingPolicy: &policy.ErrorHandlingPolicy{
+				IgnoreFileErrorsSet:      true,
+				IgnoreDirectoryErrorsSet: true,
+			},
+			fileArg: "inherit",
+			dirArg:  "inherit",
+			expResult: &policy.ErrorHandlingPolicy{
+				IgnoreFileErrors:         false,
+				IgnoreFileErrorsSet:      false,
+				IgnoreDirectoryErrors:    false,
+				IgnoreDirectoryErrorsSet: false,
+			},
+			expErr:         false,
+			expChangeCount: 2,
+		},
+		{
+			name:           "Set to true",
+			startingPolicy: &policy.ErrorHandlingPolicy{},
+			fileArg:        "true",
+			dirArg:         "true",
+			expResult: &policy.ErrorHandlingPolicy{
+				IgnoreFileErrors:         true,
+				IgnoreFileErrorsSet:      true,
+				IgnoreDirectoryErrors:    true,
+				IgnoreDirectoryErrorsSet: true,
+			},
+			expErr:         false,
+			expChangeCount: 2,
+		},
+		{
+			name: "Set to false",
+			startingPolicy: &policy.ErrorHandlingPolicy{
+				IgnoreFileErrors:      true,
+				IgnoreDirectoryErrors: true,
+			},
+			fileArg: "false",
+			dirArg:  "false",
+			expResult: &policy.ErrorHandlingPolicy{
+				IgnoreFileErrors:         false,
+				IgnoreFileErrorsSet:      true,
+				IgnoreDirectoryErrors:    false,
+				IgnoreDirectoryErrorsSet: true,
+			},
+			expErr:         false,
+			expChangeCount: 2,
+		},
+	} {
+		t.Log(tc.name)
+
+		changeCount := 0
+
+		*policyIgnoreFileErrors = tc.fileArg
+		*policyIgnoreDirectoryErrors = tc.dirArg
+
+		setErrorHandlingPolicyFromFlags(tc.startingPolicy, &changeCount)
+
+		if !reflect.DeepEqual(tc.startingPolicy, tc.expResult) {
+			t.Errorf("Did not get expected output: (actual) %v != %v (expected)", tc.startingPolicy, tc.expResult)
+		}
+	}
+}

--- a/cli/command_policy_show.go
+++ b/cli/command_policy_show.go
@@ -80,6 +80,8 @@ func printPolicy(p *policy.Policy, parents []*policy.Policy) {
 	printStdout("\n")
 	printFilesPolicy(p, parents)
 	printStdout("\n")
+	printErrorHandlingPolicy(p, parents)
+	printStdout("\n")
 	printSchedulingPolicy(p, parents)
 	printStdout("\n")
 	printCompressionPolicy(p, parents)
@@ -153,6 +155,22 @@ func printFilesPolicy(p *policy.Policy, parents []*policy.Policy) {
 				return pol.FilesPolicy.MaxFileSize != 0
 			}))
 	}
+}
+
+func printErrorHandlingPolicy(p *policy.Policy, parents []*policy.Policy) {
+	printStdout("Error handling policy:\n")
+
+	printStdout("  Ignore file read errors:       %5v       %v\n",
+		p.ErrorHandlingPolicy.IgnoreFileErrors,
+		getDefinitionPoint(parents, func(pol *policy.Policy) bool {
+			return pol.ErrorHandlingPolicy.IgnoreFileErrorsSet
+		}))
+
+	printStdout("  Ignore directory read errors:  %5v       %v\n",
+		p.ErrorHandlingPolicy.IgnoreDirectoryErrors,
+		getDefinitionPoint(parents, func(pol *policy.Policy) bool {
+			return pol.ErrorHandlingPolicy.IgnoreDirectoryErrorsSet
+		}))
 }
 
 func printSchedulingPolicy(p *policy.Policy, parents []*policy.Policy) {

--- a/cli/command_snapshot_migrate.go
+++ b/cli/command_snapshot_migrate.go
@@ -72,7 +72,7 @@ func runMigrateCommand(ctx context.Context, destRepo *repo.Repository) error {
 
 		uploader := snapshotfs.NewUploader(destRepo)
 		uploader.Progress = cliProgress
-		uploader.IgnoreFileErrors = *migrateIgnoreErrors
+		uploader.IgnoreReadErrors = *migrateIgnoreErrors
 		activeUploaders[s] = uploader
 		mu.Unlock()
 

--- a/snapshot/policy/error_handling_policy.go
+++ b/snapshot/policy/error_handling_policy.go
@@ -2,10 +2,16 @@ package policy
 
 // ErrorHandlingPolicy controls error hadnling behavior when taking snapshots.
 type ErrorHandlingPolicy struct {
-	IgnoreFileErrors    bool `json:"ignoreFileErrs,omitempty"`
+	// IgnoreFileErrors controls whether or not snapshot operation should terminate when a file throws an error on being read
+	IgnoreFileErrors bool `json:"ignoreFileErrs,omitempty"`
+
+	//IgnoreFileErrorSet denotes whether the IgnoreFileErrors bool was actually set in this policy, or if it should be inherited
 	IgnoreFileErrorsSet bool `json:"ignoreFileErrsSet,omitempty"`
 
-	IgnoreDirectoryErrors    bool `json:"ignoreDirErrs,omitempty"`
+	// IgnoreDirectoryErrors controls whether or not snapshot operation should terminate when a directory throws an error on being read or opened
+	IgnoreDirectoryErrors bool `json:"ignoreDirErrs,omitempty"`
+
+	// IgnoreDirectoryErrorsSet denotes whether the IgnoreDirectoryErrors bool was actually set in this policy, or if it should be inherited
 	IgnoreDirectoryErrorsSet bool `json:"ignoreDirErrsSet,omitempty"`
 }
 

--- a/snapshot/policy/error_handling_policy.go
+++ b/snapshot/policy/error_handling_policy.go
@@ -2,13 +2,11 @@ package policy
 
 // ErrorHandlingPolicy describes files to be ignored when taking snapshots.
 type ErrorHandlingPolicy struct {
-	IgnoreFileErrors         bool `json:"ignoreFileErrs,omitempty"`
-	IgnoreFileErrorsSet      bool `json:"ignoreFileErrsSet,omitempty"`
-	NoParentIgnoreFileErrors bool `json:"noParentIgnoreFileErrs,omitempty"`
+	IgnoreFileErrors    bool `json:"ignoreFileErrs,omitempty"`
+	IgnoreFileErrorsSet bool `json:"ignoreFileErrsSet,omitempty"`
 
-	IgnoreDirectoryErrors         bool `json:"ignoreDirErrs,omitempty"`
-	IgnoreDirectoryErrorsSet      bool `json:"ignoreDirErrsSet,omitempty"`
-	NoParentIgnoreDirectoryErrors bool `json:"noParentIgnoreDirErrs,omitempty"`
+	IgnoreDirectoryErrors    bool `json:"ignoreDirErrs,omitempty"`
+	IgnoreDirectoryErrorsSet bool `json:"ignoreDirErrsSet,omitempty"`
 }
 
 // Merge applies default values from the provided policy.

--- a/snapshot/policy/error_handling_policy.go
+++ b/snapshot/policy/error_handling_policy.go
@@ -1,6 +1,6 @@
 package policy
 
-// ErrorHandlingPolicy describes files to be ignored when taking snapshots.
+// ErrorHandlingPolicy controls error hadnling behavior when taking snapshots.
 type ErrorHandlingPolicy struct {
 	IgnoreFileErrors    bool `json:"ignoreFileErrs,omitempty"`
 	IgnoreFileErrorsSet bool `json:"ignoreFileErrsSet,omitempty"`

--- a/snapshot/policy/error_handling_policy.go
+++ b/snapshot/policy/error_handling_policy.go
@@ -1,0 +1,33 @@
+package policy
+
+// ErrorHandlingPolicy describes files to be ignored when taking snapshots.
+type ErrorHandlingPolicy struct {
+	IgnoreFileErrors         bool `json:"ignoreFileErrs,omitempty"`
+	IgnoreFileErrorsSet      bool `json:"ignoreFileErrsSet,omitempty"`
+	NoParentIgnoreFileErrors bool `json:"noParentIgnoreFileErrs,omitempty"`
+
+	IgnoreDirectoryErrors         bool `json:"ignoreDirErrs,omitempty"`
+	IgnoreDirectoryErrorsSet      bool `json:"ignoreDirErrsSet,omitempty"`
+	NoParentIgnoreDirectoryErrors bool `json:"noParentIgnoreDirErrs,omitempty"`
+}
+
+// Merge applies default values from the provided policy.
+func (p *ErrorHandlingPolicy) Merge(src ErrorHandlingPolicy) {
+	if !p.IgnoreFileErrorsSet && src.IgnoreFileErrorsSet {
+		p.IgnoreFileErrors = src.IgnoreFileErrors
+		p.IgnoreFileErrorsSet = true
+	}
+
+	if !p.IgnoreDirectoryErrorsSet && src.IgnoreDirectoryErrorsSet {
+		p.IgnoreDirectoryErrors = src.IgnoreDirectoryErrors
+		p.IgnoreDirectoryErrorsSet = true
+	}
+}
+
+// defaultErrorHandlingPolicy is the default error handling policy.
+var defaultErrorHandlingPolicy = ErrorHandlingPolicy{
+	IgnoreFileErrors:         false,
+	IgnoreFileErrorsSet:      true,
+	IgnoreDirectoryErrors:    false,
+	IgnoreDirectoryErrorsSet: true,
+}

--- a/snapshot/policy/error_handling_policy.go
+++ b/snapshot/policy/error_handling_policy.go
@@ -5,7 +5,7 @@ type ErrorHandlingPolicy struct {
 	// IgnoreFileErrors controls whether or not snapshot operation should terminate when a file throws an error on being read
 	IgnoreFileErrors bool `json:"ignoreFileErrs,omitempty"`
 
-	//IgnoreFileErrorSet denotes whether the IgnoreFileErrors bool was actually set in this policy, or if it should be inherited
+	// IgnoreFileErrorSet denotes whether the IgnoreFileErrors bool was actually set in this policy, or if it should be inherited
 	IgnoreFileErrorsSet bool `json:"ignoreFileErrsSet,omitempty"`
 
 	// IgnoreDirectoryErrors controls whether or not snapshot operation should terminate when a directory throws an error on being read or opened

--- a/snapshot/policy/error_handling_policy_test.go
+++ b/snapshot/policy/error_handling_policy_test.go
@@ -12,10 +12,12 @@ func TestErrorHandlingPolicyMerge(t *testing.T) {
 		IgnoreDirectoryErrors    bool
 		IgnoreDirectoryErrorsSet bool
 	}
+
 	type args struct {
 		src ErrorHandlingPolicy
 	}
-	tests := []struct {
+
+	for _, tt := range []struct {
 		name      string
 		fields    fields
 		args      args
@@ -205,20 +207,19 @@ func TestErrorHandlingPolicyMerge(t *testing.T) {
 				IgnoreDirectoryErrorsSet: true,
 			},
 		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			p := &ErrorHandlingPolicy{
-				IgnoreFileErrors:         tt.fields.IgnoreFileErrors,
-				IgnoreFileErrorsSet:      tt.fields.IgnoreFileErrorsSet,
-				IgnoreDirectoryErrors:    tt.fields.IgnoreDirectoryErrors,
-				IgnoreDirectoryErrorsSet: tt.fields.IgnoreDirectoryErrorsSet,
-			}
-			p.Merge(tt.args.src)
+	} {
+		t.Log(tt.name)
 
-			if !reflect.DeepEqual(*p, tt.expResult) {
-				t.Errorf("Policy after merge was not what was expected\n%v != %v", p, tt.expResult)
-			}
-		})
+		p := &ErrorHandlingPolicy{
+			IgnoreFileErrors:         tt.fields.IgnoreFileErrors,
+			IgnoreFileErrorsSet:      tt.fields.IgnoreFileErrorsSet,
+			IgnoreDirectoryErrors:    tt.fields.IgnoreDirectoryErrors,
+			IgnoreDirectoryErrorsSet: tt.fields.IgnoreDirectoryErrorsSet,
+		}
+		p.Merge(tt.args.src)
+
+		if !reflect.DeepEqual(*p, tt.expResult) {
+			t.Errorf("Policy after merge was not what was expected\n%v != %v", p, tt.expResult)
+		}
 	}
 }

--- a/snapshot/policy/error_handling_policy_test.go
+++ b/snapshot/policy/error_handling_policy_test.go
@@ -1,0 +1,224 @@
+package policy
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestErrorHandlingPolicyMerge(t *testing.T) {
+	type fields struct {
+		IgnoreFileErrors         bool
+		IgnoreFileErrorsSet      bool
+		IgnoreDirectoryErrors    bool
+		IgnoreDirectoryErrorsSet bool
+	}
+	type args struct {
+		src ErrorHandlingPolicy
+	}
+	tests := []struct {
+		name      string
+		fields    fields
+		args      args
+		expResult ErrorHandlingPolicy
+	}{
+		{
+			name: "Policy being merged has no value set - expect no change",
+			fields: fields{
+				IgnoreFileErrors:         false,
+				IgnoreFileErrorsSet:      false,
+				IgnoreDirectoryErrors:    false,
+				IgnoreDirectoryErrorsSet: false,
+			},
+			args: args{
+				src: ErrorHandlingPolicy{
+					IgnoreFileErrors:         false,
+					IgnoreFileErrorsSet:      false,
+					IgnoreDirectoryErrors:    false,
+					IgnoreDirectoryErrorsSet: false,
+				},
+			},
+			expResult: ErrorHandlingPolicy{
+				IgnoreFileErrors:         false,
+				IgnoreFileErrorsSet:      false,
+				IgnoreDirectoryErrors:    false,
+				IgnoreDirectoryErrorsSet: false,
+			},
+		},
+		{
+			name: "Policy being merged has a true value but it wasn't actually set - expect no change",
+			fields: fields{
+				IgnoreFileErrors:         false,
+				IgnoreFileErrorsSet:      false,
+				IgnoreDirectoryErrors:    false,
+				IgnoreDirectoryErrorsSet: false,
+			},
+			args: args{
+				src: ErrorHandlingPolicy{
+					IgnoreFileErrors:         true,
+					IgnoreFileErrorsSet:      false,
+					IgnoreDirectoryErrors:    false,
+					IgnoreDirectoryErrorsSet: false,
+				},
+			},
+			expResult: ErrorHandlingPolicy{
+				IgnoreFileErrors:         false,
+				IgnoreFileErrorsSet:      false,
+				IgnoreDirectoryErrors:    false,
+				IgnoreDirectoryErrorsSet: false,
+			},
+		},
+		{
+			name: "Starting policy has a true value but not set - expect no change",
+			fields: fields{
+				IgnoreFileErrors:         true,
+				IgnoreFileErrorsSet:      false,
+				IgnoreDirectoryErrors:    false,
+				IgnoreDirectoryErrorsSet: false,
+			},
+			args: args{
+				src: ErrorHandlingPolicy{
+					IgnoreFileErrors:         false,
+					IgnoreFileErrorsSet:      false,
+					IgnoreDirectoryErrors:    false,
+					IgnoreDirectoryErrorsSet: false,
+				},
+			},
+			expResult: ErrorHandlingPolicy{
+				IgnoreFileErrors:         true,
+				IgnoreFileErrorsSet:      false,
+				IgnoreDirectoryErrors:    false,
+				IgnoreDirectoryErrorsSet: false,
+			},
+		},
+		{
+			name: "Policy being merged has a value set at false - expect result to have value set at false",
+			fields: fields{
+				IgnoreFileErrors:         false,
+				IgnoreFileErrorsSet:      false,
+				IgnoreDirectoryErrors:    false,
+				IgnoreDirectoryErrorsSet: false,
+			},
+			args: args{
+				src: ErrorHandlingPolicy{
+					IgnoreFileErrors:         false,
+					IgnoreFileErrorsSet:      true,
+					IgnoreDirectoryErrors:    false,
+					IgnoreDirectoryErrorsSet: false,
+				},
+			},
+			expResult: ErrorHandlingPolicy{
+				IgnoreFileErrors:         false,
+				IgnoreFileErrorsSet:      true,
+				IgnoreDirectoryErrors:    false,
+				IgnoreDirectoryErrorsSet: false,
+			},
+		},
+		{
+			name: "Policy being merged has a value set at true - expect result to have value set at true",
+			fields: fields{
+				IgnoreFileErrors:         false,
+				IgnoreFileErrorsSet:      false,
+				IgnoreDirectoryErrors:    false,
+				IgnoreDirectoryErrorsSet: false,
+			},
+			args: args{
+				src: ErrorHandlingPolicy{
+					IgnoreFileErrors:         true,
+					IgnoreFileErrorsSet:      true,
+					IgnoreDirectoryErrors:    false,
+					IgnoreDirectoryErrorsSet: false,
+				},
+			},
+			expResult: ErrorHandlingPolicy{
+				IgnoreFileErrors:         true,
+				IgnoreFileErrorsSet:      true,
+				IgnoreDirectoryErrors:    false,
+				IgnoreDirectoryErrorsSet: false,
+			},
+		},
+		{
+			name: "Starting policy already has a value set at false - expect no change from merged policy",
+			fields: fields{
+				IgnoreFileErrors:         false,
+				IgnoreFileErrorsSet:      true,
+				IgnoreDirectoryErrors:    false,
+				IgnoreDirectoryErrorsSet: false,
+			},
+			args: args{
+				src: ErrorHandlingPolicy{
+					IgnoreFileErrors:         true,
+					IgnoreFileErrorsSet:      true,
+					IgnoreDirectoryErrors:    false,
+					IgnoreDirectoryErrorsSet: false,
+				},
+			},
+			expResult: ErrorHandlingPolicy{
+				IgnoreFileErrors:         false,
+				IgnoreFileErrorsSet:      true,
+				IgnoreDirectoryErrors:    false,
+				IgnoreDirectoryErrorsSet: false,
+			},
+		},
+		{
+			name: "Policy being merged has a value set at true - expect no change from merged policy",
+			fields: fields{
+				IgnoreFileErrors:         true,
+				IgnoreFileErrorsSet:      true,
+				IgnoreDirectoryErrors:    false,
+				IgnoreDirectoryErrorsSet: false,
+			},
+			args: args{
+				src: ErrorHandlingPolicy{
+					IgnoreFileErrors:         false,
+					IgnoreFileErrorsSet:      true,
+					IgnoreDirectoryErrors:    false,
+					IgnoreDirectoryErrorsSet: false,
+				},
+			},
+			expResult: ErrorHandlingPolicy{
+				IgnoreFileErrors:         true,
+				IgnoreFileErrorsSet:      true,
+				IgnoreDirectoryErrors:    false,
+				IgnoreDirectoryErrorsSet: false,
+			},
+		},
+		{
+			name: "Both error behavior changed at once",
+			fields: fields{
+				IgnoreFileErrors:         false,
+				IgnoreFileErrorsSet:      false,
+				IgnoreDirectoryErrors:    false,
+				IgnoreDirectoryErrorsSet: false,
+			},
+			args: args{
+				src: ErrorHandlingPolicy{
+					IgnoreFileErrors:         true,
+					IgnoreFileErrorsSet:      true,
+					IgnoreDirectoryErrors:    true,
+					IgnoreDirectoryErrorsSet: true,
+				},
+			},
+			expResult: ErrorHandlingPolicy{
+				IgnoreFileErrors:         true,
+				IgnoreFileErrorsSet:      true,
+				IgnoreDirectoryErrors:    true,
+				IgnoreDirectoryErrorsSet: true,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &ErrorHandlingPolicy{
+				IgnoreFileErrors:         tt.fields.IgnoreFileErrors,
+				IgnoreFileErrorsSet:      tt.fields.IgnoreFileErrorsSet,
+				IgnoreDirectoryErrors:    tt.fields.IgnoreDirectoryErrors,
+				IgnoreDirectoryErrorsSet: tt.fields.IgnoreDirectoryErrorsSet,
+			}
+			p.Merge(tt.args.src)
+
+			if !reflect.DeepEqual(*p, tt.expResult) {
+				t.Errorf("Policy after merge was not what was expected\n%v != %v", p, tt.expResult)
+			}
+		})
+	}
+}

--- a/snapshot/policy/error_handling_policy_test.go
+++ b/snapshot/policy/error_handling_policy_test.go
@@ -58,7 +58,7 @@ func TestErrorHandlingPolicyMerge(t *testing.T) {
 				src: ErrorHandlingPolicy{
 					IgnoreFileErrors:         true,
 					IgnoreFileErrorsSet:      false,
-					IgnoreDirectoryErrors:    false,
+					IgnoreDirectoryErrors:    true,
 					IgnoreDirectoryErrorsSet: false,
 				},
 			},
@@ -74,7 +74,7 @@ func TestErrorHandlingPolicyMerge(t *testing.T) {
 			fields: fields{
 				IgnoreFileErrors:         true,
 				IgnoreFileErrorsSet:      false,
-				IgnoreDirectoryErrors:    false,
+				IgnoreDirectoryErrors:    true,
 				IgnoreDirectoryErrorsSet: false,
 			},
 			args: args{
@@ -88,7 +88,7 @@ func TestErrorHandlingPolicyMerge(t *testing.T) {
 			expResult: ErrorHandlingPolicy{
 				IgnoreFileErrors:         true,
 				IgnoreFileErrorsSet:      false,
-				IgnoreDirectoryErrors:    false,
+				IgnoreDirectoryErrors:    true,
 				IgnoreDirectoryErrorsSet: false,
 			},
 		},
@@ -105,87 +105,18 @@ func TestErrorHandlingPolicyMerge(t *testing.T) {
 					IgnoreFileErrors:         false,
 					IgnoreFileErrorsSet:      true,
 					IgnoreDirectoryErrors:    false,
-					IgnoreDirectoryErrorsSet: false,
+					IgnoreDirectoryErrorsSet: true,
 				},
 			},
 			expResult: ErrorHandlingPolicy{
 				IgnoreFileErrors:         false,
 				IgnoreFileErrorsSet:      true,
 				IgnoreDirectoryErrors:    false,
-				IgnoreDirectoryErrorsSet: false,
+				IgnoreDirectoryErrorsSet: true,
 			},
 		},
 		{
 			name: "Policy being merged has a value set at true - expect result to have value set at true",
-			fields: fields{
-				IgnoreFileErrors:         false,
-				IgnoreFileErrorsSet:      false,
-				IgnoreDirectoryErrors:    false,
-				IgnoreDirectoryErrorsSet: false,
-			},
-			args: args{
-				src: ErrorHandlingPolicy{
-					IgnoreFileErrors:         true,
-					IgnoreFileErrorsSet:      true,
-					IgnoreDirectoryErrors:    false,
-					IgnoreDirectoryErrorsSet: false,
-				},
-			},
-			expResult: ErrorHandlingPolicy{
-				IgnoreFileErrors:         true,
-				IgnoreFileErrorsSet:      true,
-				IgnoreDirectoryErrors:    false,
-				IgnoreDirectoryErrorsSet: false,
-			},
-		},
-		{
-			name: "Starting policy already has a value set at false - expect no change from merged policy",
-			fields: fields{
-				IgnoreFileErrors:         false,
-				IgnoreFileErrorsSet:      true,
-				IgnoreDirectoryErrors:    false,
-				IgnoreDirectoryErrorsSet: false,
-			},
-			args: args{
-				src: ErrorHandlingPolicy{
-					IgnoreFileErrors:         true,
-					IgnoreFileErrorsSet:      true,
-					IgnoreDirectoryErrors:    false,
-					IgnoreDirectoryErrorsSet: false,
-				},
-			},
-			expResult: ErrorHandlingPolicy{
-				IgnoreFileErrors:         false,
-				IgnoreFileErrorsSet:      true,
-				IgnoreDirectoryErrors:    false,
-				IgnoreDirectoryErrorsSet: false,
-			},
-		},
-		{
-			name: "Policy being merged has a value set at true - expect no change from merged policy",
-			fields: fields{
-				IgnoreFileErrors:         true,
-				IgnoreFileErrorsSet:      true,
-				IgnoreDirectoryErrors:    false,
-				IgnoreDirectoryErrorsSet: false,
-			},
-			args: args{
-				src: ErrorHandlingPolicy{
-					IgnoreFileErrors:         false,
-					IgnoreFileErrorsSet:      true,
-					IgnoreDirectoryErrors:    false,
-					IgnoreDirectoryErrorsSet: false,
-				},
-			},
-			expResult: ErrorHandlingPolicy{
-				IgnoreFileErrors:         true,
-				IgnoreFileErrorsSet:      true,
-				IgnoreDirectoryErrors:    false,
-				IgnoreDirectoryErrorsSet: false,
-			},
-		},
-		{
-			name: "Both error behavior changed at once",
 			fields: fields{
 				IgnoreFileErrors:         false,
 				IgnoreFileErrorsSet:      false,
@@ -203,6 +134,98 @@ func TestErrorHandlingPolicyMerge(t *testing.T) {
 			expResult: ErrorHandlingPolicy{
 				IgnoreFileErrors:         true,
 				IgnoreFileErrorsSet:      true,
+				IgnoreDirectoryErrors:    true,
+				IgnoreDirectoryErrorsSet: true,
+			},
+		},
+		{
+			name: "Starting policy already has a value set at false - expect no change from merged policy",
+			fields: fields{
+				IgnoreFileErrors:         false,
+				IgnoreFileErrorsSet:      true,
+				IgnoreDirectoryErrors:    false,
+				IgnoreDirectoryErrorsSet: true,
+			},
+			args: args{
+				src: ErrorHandlingPolicy{
+					IgnoreFileErrors:         true,
+					IgnoreFileErrorsSet:      true,
+					IgnoreDirectoryErrors:    true,
+					IgnoreDirectoryErrorsSet: true,
+				},
+			},
+			expResult: ErrorHandlingPolicy{
+				IgnoreFileErrors:         false,
+				IgnoreFileErrorsSet:      true,
+				IgnoreDirectoryErrors:    false,
+				IgnoreDirectoryErrorsSet: true,
+			},
+		},
+		{
+			name: "Value was true in starting policy but not set - expect to be overridden by incoming policy",
+			fields: fields{
+				IgnoreFileErrors:         true,
+				IgnoreFileErrorsSet:      false,
+				IgnoreDirectoryErrors:    true,
+				IgnoreDirectoryErrorsSet: false,
+			},
+			args: args{
+				src: ErrorHandlingPolicy{
+					IgnoreFileErrors:         false,
+					IgnoreFileErrorsSet:      true,
+					IgnoreDirectoryErrors:    false,
+					IgnoreDirectoryErrorsSet: true,
+				},
+			},
+			expResult: ErrorHandlingPolicy{
+				IgnoreFileErrors:         false,
+				IgnoreFileErrorsSet:      true,
+				IgnoreDirectoryErrors:    false,
+				IgnoreDirectoryErrorsSet: true,
+			},
+		},
+		{
+			name: "Policy being merged has a value set at true - expect no change from merged policy",
+			fields: fields{
+				IgnoreFileErrors:         true,
+				IgnoreFileErrorsSet:      true,
+				IgnoreDirectoryErrors:    true,
+				IgnoreDirectoryErrorsSet: true,
+			},
+			args: args{
+				src: ErrorHandlingPolicy{
+					IgnoreFileErrors:         false,
+					IgnoreFileErrorsSet:      true,
+					IgnoreDirectoryErrors:    false,
+					IgnoreDirectoryErrorsSet: true,
+				},
+			},
+			expResult: ErrorHandlingPolicy{
+				IgnoreFileErrors:         true,
+				IgnoreFileErrorsSet:      true,
+				IgnoreDirectoryErrors:    true,
+				IgnoreDirectoryErrorsSet: true,
+			},
+		},
+		{
+			name: "Change just one param",
+			fields: fields{
+				IgnoreFileErrors:         false,
+				IgnoreFileErrorsSet:      false,
+				IgnoreDirectoryErrors:    false,
+				IgnoreDirectoryErrorsSet: false,
+			},
+			args: args{
+				src: ErrorHandlingPolicy{
+					IgnoreFileErrors:         false,
+					IgnoreFileErrorsSet:      false,
+					IgnoreDirectoryErrors:    true,
+					IgnoreDirectoryErrorsSet: true,
+				},
+			},
+			expResult: ErrorHandlingPolicy{
+				IgnoreFileErrors:         false,
+				IgnoreFileErrorsSet:      false,
 				IgnoreDirectoryErrors:    true,
 				IgnoreDirectoryErrorsSet: true,
 			},

--- a/snapshot/policy/policy.go
+++ b/snapshot/policy/policy.go
@@ -13,12 +13,13 @@ var ErrPolicyNotFound = errors.New("policy not found")
 
 // Policy describes snapshot policy for a single source.
 type Policy struct {
-	Labels            map[string]string `json:"-"`
-	RetentionPolicy   RetentionPolicy   `json:"retention,omitempty"`
-	FilesPolicy       FilesPolicy       `json:"files,omitempty"`
-	SchedulingPolicy  SchedulingPolicy  `json:"scheduling,omitempty"`
-	CompressionPolicy CompressionPolicy `json:"compression,omitempty"`
-	NoParent          bool              `json:"noParent,omitempty"`
+	Labels              map[string]string   `json:"-"`
+	RetentionPolicy     RetentionPolicy     `json:"retention,omitempty"`
+	FilesPolicy         FilesPolicy         `json:"files,omitempty"`
+	ErrorHandlingPolicy ErrorHandlingPolicy `json:"errorhandling,omitempty"`
+	SchedulingPolicy    SchedulingPolicy    `json:"scheduling,omitempty"`
+	CompressionPolicy   CompressionPolicy   `json:"compression,omitempty"`
+	NoParent            bool                `json:"noParent,omitempty"`
 }
 
 func (p *Policy) String() string {
@@ -59,6 +60,7 @@ func MergePolicies(policies []*Policy) *Policy {
 
 		merged.RetentionPolicy.Merge(p.RetentionPolicy)
 		merged.FilesPolicy.Merge(p.FilesPolicy)
+		merged.ErrorHandlingPolicy.Merge(p.ErrorHandlingPolicy)
 		merged.SchedulingPolicy.Merge(p.SchedulingPolicy)
 		merged.CompressionPolicy.Merge(p.CompressionPolicy)
 	}
@@ -66,6 +68,7 @@ func MergePolicies(policies []*Policy) *Policy {
 	// Merge default expiration policy.
 	merged.RetentionPolicy.Merge(defaultRetentionPolicy)
 	merged.FilesPolicy.Merge(defaultFilesPolicy)
+	merged.ErrorHandlingPolicy.Merge(defaultErrorHandlingPolicy)
 	merged.SchedulingPolicy.Merge(defaultSchedulingPolicy)
 	merged.CompressionPolicy.Merge(defaultCompressionPolicy)
 

--- a/snapshot/snapshotfs/upload.go
+++ b/snapshot/snapshotfs/upload.go
@@ -331,7 +331,7 @@ func (u *Uploader) processSubdirectories(ctx context.Context, relativePath strin
 		if err != nil {
 			// Note: This only catches errors in subdirectories of the snapshot root, not on the snapshot
 			// root itself. The intention is to always fail if the top level directory can't be read,
-			// otherwise a meaningless snapshot is created that can't be restored.
+			// otherwise a meaningless, empty snapshot is created that can't be restored.
 			ignoreDirErr := u.IgnoreReadErrors || policyTree.EffectivePolicy().ErrorHandlingPolicy.IgnoreDirectoryErrors
 			if _, ok := err.(dirReadError); ok && ignoreDirErr {
 				log.Warningf("unable to read directory %q: %s, ignoring", dir.Name(), err)

--- a/snapshot/snapshotfs/upload.go
+++ b/snapshot/snapshotfs/upload.go
@@ -329,6 +329,9 @@ func (u *Uploader) processSubdirectories(ctx context.Context, relativePath strin
 		}
 
 		if err != nil {
+			// Note: This only catches errors in subdirectories of the snapshot root, not on the snapshot
+			// root itself. The intention is to always fail if the top level directory can't be read,
+			// otherwise a meaningless snapshot is created that can't be restored.
 			ignoreDirErr := u.IgnoreReadErrors || policyTree.EffectivePolicy().ErrorHandlingPolicy.IgnoreDirectoryErrors
 			if _, ok := err.(dirReadError); ok && ignoreDirErr {
 				log.Warningf("unable to read directory %q: %s, ignoring", dir.Name(), err)

--- a/snapshot/snapshotfs/upload.go
+++ b/snapshot/snapshotfs/upload.go
@@ -330,7 +330,7 @@ func (u *Uploader) processSubdirectories(ctx context.Context, relativePath strin
 
 		if err != nil {
 			ignoreDirErr := policyTree.EffectivePolicy().ErrorHandlingPolicy.IgnoreDirectoryErrors
-			if _, ok := err.(DirReadError); ok && ignoreDirErr {
+			if _, ok := err.(dirReadError); ok && ignoreDirErr {
 				log.Warningf("unable to read directory %q: %s, ignoring", dir.Name(), err)
 				return nil
 			}
@@ -611,9 +611,8 @@ func uniqueDirectories(dirs []fs.Directory) []fs.Directory {
 	return result
 }
 
-// DirReadError distinguishes an error thrown when attempting to
-// read a directory
-type DirReadError struct {
+// dirReadError distinguishes an error thrown when attempting to read a directory
+type dirReadError struct {
 	error
 }
 
@@ -641,7 +640,7 @@ func uploadDirInternal(
 	log.Debugf("finished reading directory %v", dirRelativePath)
 
 	if direrr != nil {
-		return "", fs.DirectorySummary{}, DirReadError{direrr}
+		return "", fs.DirectorySummary{}, dirReadError{direrr}
 	}
 
 	var prevEntries []fs.Entries

--- a/snapshot/snapshotfs/upload_test.go
+++ b/snapshot/snapshotfs/upload_test.go
@@ -205,7 +205,7 @@ func TestUpload_TopLevelDirectoryReadFailure(t *testing.T) {
 	policyTree := policy.BuildTree(nil, policy.DefaultPolicy)
 
 	s, err := u.Upload(ctx, th.sourceDir, policyTree, snapshot.SourceInfo{})
-	if err != errTest {
+	if err.Error() != errTest.Error() {
 		t.Errorf("expected error: %v", err)
 	}
 

--- a/snapshot/snapshotfs/upload_test.go
+++ b/snapshot/snapshotfs/upload_test.go
@@ -223,7 +223,7 @@ func TestUpload_SubDirectoryReadFailure(t *testing.T) {
 	th.sourceDir.Subdir("d1").FailReaddir(errTest)
 
 	u := NewUploader(th.repo)
-	u.IgnoreFileErrors = false
+	u.IgnoreReadErrors = false
 
 	policyTree := policy.BuildTree(nil, policy.DefaultPolicy)
 

--- a/tests/end_to_end_test/restore_fail_test.go
+++ b/tests/end_to_end_test/restore_fail_test.go
@@ -1,0 +1,104 @@
+package endtoend_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kopia/kopia/repo/content"
+	"github.com/kopia/kopia/tests/testenv"
+)
+
+// TestRestoreFail
+// Motivation: Cause a kopia snapshot restore command to fail, ensure non-zero exit code.
+// Description:
+//		1. Create kopia repo
+//		2. Create a directory tree for testing
+//		3. Issue kopia blob list before issuing any snapshots
+//		4. Create a snapshot of the source directory, parse the snapshot ID
+//		5. Issue another kopia blob list, find the blob IDs that were not
+//			present in the previous blob list.
+//		6. Find a pack blob by searching for a blob ID with the "p" prefix
+//		7. Issue kopia blob delete on the ID of the found pack blob
+//		8. Attempt a snapshot restore on the snapshot, expecting failure
+// Pass Criteria: Kopia commands issue successfully, except the final restore
+//		command is expected to fail. Expect to find new blobs after a snapshot
+//		and expect one of them is a pack blob type prefixed with "p".
+func TestRestoreFail(t *testing.T) {
+	t.Parallel()
+
+	e := testenv.NewCLITest(t)
+	defer e.Cleanup(t)
+	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
+
+	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
+
+	scratchDir := makeScratchDir(t)
+	sourceDir := filepath.Join(scratchDir, "source")
+	targetDir := filepath.Join(scratchDir, "target")
+
+	testenv.MustCreateDirectoryTree(t, sourceDir, testenv.DirectoryTreeOptions{
+		Depth:                  2,
+		MaxSubdirsPerDirectory: 10,
+		MaxFilesPerDirectory:   10,
+	})
+
+	beforeBlobList := e.RunAndExpectSuccess(t, "blob", "list")
+
+	_, errOut := e.RunAndExpectSuccessWithErrOut(t, "snapshot", "create", sourceDir)
+	snapID := parseSnapID(t, errOut)
+
+	afterBlobList := e.RunAndExpectSuccess(t, "blob", "list")
+
+	newBlobIDs := getNewBlobIDs(beforeBlobList, afterBlobList)
+
+	var blobIDToDelete string
+
+	for _, blobID := range newBlobIDs {
+		if strings.Contains(blobID, string(content.PackBlobIDPrefixRegular)) {
+			blobIDToDelete = blobID
+		}
+	}
+
+	if blobIDToDelete == "" {
+		t.Fatal("Could not find a pack blob in the list of blobs created by snapshot")
+	}
+
+	// Delete a pack blob
+	e.RunAndExpectSuccess(t, "blob", "delete", blobIDToDelete)
+
+	// Expect a subsequent restore to fail
+	e.RunAndExpectFailure(t, "snapshot", "restore", snapID, targetDir)
+}
+
+func getNewBlobIDs(before, after []string) []string {
+	newIDMap := make(map[string]struct{})
+
+	// Add all blob IDs seen after the snapshot
+	for _, outputStr := range after {
+		blobID := parseBlobIDFromBlobList(outputStr)
+		newIDMap[blobID] = struct{}{}
+	}
+
+	// Remove all blob IDs seen before the snapshot
+	for _, outputStr := range before {
+		blobID := parseBlobIDFromBlobList(outputStr)
+		delete(newIDMap, blobID)
+	}
+
+	idList := make([]string, 0, len(newIDMap))
+	for blobID := range newIDMap {
+		idList = append(idList, blobID)
+	}
+
+	return idList
+}
+
+func parseBlobIDFromBlobList(str string) string {
+	fields := strings.Fields(str)
+	if len(fields) > 0 {
+		return fields[0]
+	}
+
+	return ""
+}

--- a/tests/testenv/cli_test_env.go
+++ b/tests/testenv/cli_test_env.go
@@ -242,7 +242,7 @@ func trimOutput(s string) string {
 
 // ListSnapshotsAndExpectSuccess lists given snapshots and parses the output.
 func (e *CLITest) ListSnapshotsAndExpectSuccess(t *testing.T, targets ...string) []SourceInfo {
-	lines := e.RunAndExpectSuccess(t, append([]string{"snapshot", "list", "-l", "--manifest-id"}, targets...)...)
+	lines := e.RunAndExpectSuccess(t, append([]string{"snapshot", "list", "-l", "--manifest-id", "--max-results", "400"}, targets...)...)
 	return mustParseSnapshots(t, lines)
 }
 


### PR DESCRIPTION
Adding flags to `kopia policy set` for file and directory read error handling.
Flag value can be true, false, or `inherit`. Manually tested the different combinations to ensure it was inheriting properly when not explicitly set in a given policy. Opening PR for early feedback to confirm this is the right direction for controlling this behavior.