### PR TITLE
Remove content.CompactOptions.MinSmallBlobs

### DIFF
--- a/cli/command_index_optimize.go
+++ b/cli/command_index_optimize.go
@@ -9,7 +9,6 @@ import (
 
 var (
 	optimizeCommand              = indexCommands.Command("optimize", "Optimize indexes blobs.")
-	optimizeMinSmallBlobs        = optimizeCommand.Flag("min-small-blobs", "Minimum number of small index blobs that can be left after compaction.").Default("1").Int()
 	optimizeMaxSmallBlobs        = optimizeCommand.Flag("max-small-blobs", "Maximum number of small index blobs that can be left after compaction.").Default("1").Int()
 	optimizeSkipDeletedOlderThan = optimizeCommand.Flag("skip-deleted-older-than", "Skip deleted blobs above given age").Duration()
 	optimizeAllIndexes           = optimizeCommand.Flag("all", "Optimize all indexes, even those above maximum size.").Bool()
@@ -17,7 +16,6 @@ var (
 
 func runOptimizeCommand(ctx context.Context, rep *repo.Repository) error {
 	return rep.Content.CompactIndexes(ctx, content.CompactOptions{
-		MinSmallBlobs:        *optimizeMinSmallBlobs,
 		MaxSmallBlobs:        *optimizeMaxSmallBlobs,
 		AllIndexes:           *optimizeAllIndexes,
 		SkipDeletedOlderThan: *optimizeSkipDeletedOlderThan,

--- a/repo/content/content_manager_test.go
+++ b/repo/content/content_manager_test.go
@@ -374,10 +374,7 @@ func TestContentManagerConcurrency(t *testing.T) {
 		t.Errorf("unexpected index count before compaction: %v, wanted %v", got, want)
 	}
 
-	if err := bm4.CompactIndexes(ctx, CompactOptions{
-		MinSmallBlobs: 1,
-		MaxSmallBlobs: 1,
-	}); err != nil {
+	if err := bm4.CompactIndexes(ctx, CompactOptions{MaxSmallBlobs: 1}); err != nil {
 		t.Errorf("compaction error: %v", err)
 	}
 
@@ -393,10 +390,7 @@ func TestContentManagerConcurrency(t *testing.T) {
 	verifyContent(ctx, t, bm5, bm2content, seededRandomData(32, 100))
 	verifyContent(ctx, t, bm5, bm3content, seededRandomData(33, 100))
 
-	if err := bm5.CompactIndexes(ctx, CompactOptions{
-		MinSmallBlobs: 1,
-		MaxSmallBlobs: 1,
-	}); err != nil {
+	if err := bm5.CompactIndexes(ctx, CompactOptions{MaxSmallBlobs: 1}); err != nil {
 		t.Errorf("compaction error: %v", err)
 	}
 }
@@ -1233,10 +1227,7 @@ func verifyVersionCompat(t *testing.T, writeVersion int) {
 	// make sure we can read everything
 	verifyContentManagerDataSet(ctx, t, mgr, dataSet)
 
-	if err := mgr.CompactIndexes(ctx, CompactOptions{
-		MinSmallBlobs: 1,
-		MaxSmallBlobs: 1,
-	}); err != nil {
+	if err := mgr.CompactIndexes(ctx, CompactOptions{MaxSmallBlobs: 1}); err != nil {
 		t.Fatalf("unable to compact indexes: %v", err)
 	}
 

--- a/repo/repository_test.go
+++ b/repo/repository_test.go
@@ -124,7 +124,7 @@ func TestPackingSimple(t *testing.T) {
 	verify(ctx, t, env.Repository, oid2a, []byte(content2), "packed-object-2")
 	verify(ctx, t, env.Repository, oid3a, []byte(content3), "packed-object-3")
 
-	if err := env.Repository.Content.CompactIndexes(ctx, content.CompactOptions{MinSmallBlobs: 1, MaxSmallBlobs: 1}); err != nil {
+	if err := env.Repository.Content.CompactIndexes(ctx, content.CompactOptions{MaxSmallBlobs: 1}); err != nil {
 		t.Errorf("optimize error: %v", err)
 	}
 
@@ -134,7 +134,7 @@ func TestPackingSimple(t *testing.T) {
 	verify(ctx, t, env.Repository, oid2a, []byte(content2), "packed-object-2")
 	verify(ctx, t, env.Repository, oid3a, []byte(content3), "packed-object-3")
 
-	if err := env.Repository.Content.CompactIndexes(ctx, content.CompactOptions{MinSmallBlobs: 1, MaxSmallBlobs: 1}); err != nil {
+	if err := env.Repository.Content.CompactIndexes(ctx, content.CompactOptions{MaxSmallBlobs: 1}); err != nil {
 		t.Errorf("optimize error: %v", err)
 	}
 

--- a/tests/repository_stress_test/repository_stress_test.go
+++ b/tests/repository_stress_test/repository_stress_test.go
@@ -280,10 +280,7 @@ func listAndReadAllContents(ctx context.Context, t *testing.T, r *repo.Repositor
 }
 
 func compact(ctx context.Context, t *testing.T, r *repo.Repository) error {
-	return r.Content.CompactIndexes(ctx, content.CompactOptions{
-		MinSmallBlobs: 1,
-		MaxSmallBlobs: 1,
-	})
+	return r.Content.CompactIndexes(ctx, content.CompactOptions{MaxSmallBlobs: 1})
 }
 
 func flush(ctx context.Context, t *testing.T, r *repo.Repository) error {


### PR DESCRIPTION
Use `MaxSmallBlobs` instead. `MaxSmallBlobs` was not being really used.
Replaced uses of `MinSmallBlobs` with `MaxSmallBlobs` and removed `MinSmallBlobs`