### PR TITLE
Avoid index entry removal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ dist: bionic
 language: go
 go:
 - 1.13.x
-os:
-- linux
-- osx
-- windows
 addons:
   apt:
     packages:
@@ -17,14 +13,8 @@ before_install:
         choco install --no-progress -y make unzip curl
         ;;
     esac
-install: make travis-setup
+install: go mod download
 script: make travis-release
-cache:
-  directories:
-  - $HOME/.cache/electron
-  - $HOME/.cache/electron-builder
-  - $HOME/.cache/electron-docker
-  - $HOME/.cache/electron-builder-docker
 deploy:
 - provider: releases
   api_key:
@@ -48,6 +38,6 @@ deploy:
     branch: master
     condition: $TRAVIS_OS_NAME = linux
 git:
-  depth: 9999999
+  depth: 3
 env:
 - GO111MODULE=on

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ quick-install:
 	# same as install but assumes HTMLUI has been built
 	go install -tags embedhtml
 
-install-noui: 
+install-noui:
 	go install
 
 escape-analysis:
@@ -144,7 +144,7 @@ dev-deps:
 	GO111MODULE=off go get -u github.com/lukehoban/go-outline
 	GO111MODULE=off go get -u github.com/newhook/go-symbols
 	GO111MODULE=off go get -u github.com/sqs/goreturns
-	
+
 test-with-coverage:
 	$(GO_TEST) -count=1 -coverprofile=tmp.cov --coverpkg $(COVERAGE_PACKAGES) -timeout 90s `go list ./...`
 

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ travis-release: install kopia-ui
 endif
 
 ifeq ($(TRAVIS_OS_NAME),linux)
-travis-release: goreleaser kopia-ui website
+travis-release: install-noui
 	$(MAKE) test-all
 	$(MAKE) integration-tests
 	$(MAKE) stress-test

--- a/repo/content/block_manager_compaction.go
+++ b/repo/content/block_manager_compaction.go
@@ -137,10 +137,6 @@ func (bm *Manager) addIndexBlobsToBuilder(ctx context.Context, bld packIndexBuil
 	}
 
 	_ = index.Iterate("", func(i Info) error {
-		if i.Deleted && opt.SkipDeletedOlderThan > 0 && time.Since(i.Timestamp()) > opt.SkipDeletedOlderThan {
-			log.Debugf("skipping content %v deleted at %v", i.ID, i.Timestamp())
-			return nil
-		}
 		bld.Add(i)
 		return nil
 	})

--- a/repo/content/block_manager_compaction.go
+++ b/repo/content/block_manager_compaction.go
@@ -35,7 +35,7 @@ func (bm *Manager) CompactIndexes(ctx context.Context, opt CompactOptions) error
 
 	contentsToCompact := bm.getContentsToCompact(indexBlobs, opt)
 
-	if err := bm.compactAndDeleteIndexBlobs(ctx, contentsToCompact, opt); err != nil {
+	if err := bm.compactAndDeleteIndexBlobs(ctx, contentsToCompact); err != nil {
 		log.Warningf("error performing quick compaction: %v", err)
 	}
 
@@ -82,7 +82,7 @@ func (bm *Manager) getContentsToCompact(indexBlobs []IndexBlobInfo, opt CompactO
 	return nonCompactedBlobs
 }
 
-func (bm *Manager) compactAndDeleteIndexBlobs(ctx context.Context, indexBlobs []IndexBlobInfo, opt CompactOptions) error {
+func (bm *Manager) compactAndDeleteIndexBlobs(ctx context.Context, indexBlobs []IndexBlobInfo) error {
 	if len(indexBlobs) <= 1 {
 		return nil
 	}
@@ -93,7 +93,7 @@ func (bm *Manager) compactAndDeleteIndexBlobs(ctx context.Context, indexBlobs []
 	bld := make(packIndexBuilder)
 
 	for _, indexBlob := range indexBlobs {
-		if err := bm.addIndexBlobsToBuilder(ctx, bld, indexBlob, opt); err != nil {
+		if err := bm.addIndexBlobsToBuilder(ctx, bld, indexBlob); err != nil {
 			return err
 		}
 	}
@@ -125,7 +125,7 @@ func (bm *Manager) compactAndDeleteIndexBlobs(ctx context.Context, indexBlobs []
 	return nil
 }
 
-func (bm *Manager) addIndexBlobsToBuilder(ctx context.Context, bld packIndexBuilder, indexBlob IndexBlobInfo, opt CompactOptions) error {
+func (bm *Manager) addIndexBlobsToBuilder(ctx context.Context, bld packIndexBuilder, indexBlob IndexBlobInfo) error {
 	data, err := bm.getIndexBlobInternal(ctx, indexBlob.BlobID)
 	if err != nil {
 		return err


### PR DESCRIPTION
Ensures that content is not accidentally removed from the indices during _quick_ index compaction.