### PR TITLE
Add walk-cross-device to walk policy

### DIFF
--- a/tests/tools/fswalker/walker/walker.go
+++ b/tests/tools/fswalker/walker/walker.go
@@ -65,5 +65,6 @@ func WalkPathHash(ctx context.Context, path string) (*fspb.Walk, error) {
 		Include:         []string{path},
 		HashPfx:         []string{""}, // Hash everything
 		MaxHashFileSize: MaxFileSizeToHash,
+		WalkCrossDevice: true,
 	})
 }

--- a/tests/tools/fswalker/walker/walker_test.go
+++ b/tests/tools/fswalker/walker/walker_test.go
@@ -37,6 +37,7 @@ func TestWalk(t *testing.T) {
 			Include: []string{
 				dataDir,
 			},
+			WalkCrossDevice: true,
 		})
 	testenv.AssertNoError(t, err)
 


### PR DESCRIPTION
Should fix issue seen in shippable testing, where files were skipped in the walk for being cross-device.