### PR TITLE
Fix typo in makefile so CI can pass

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ upload-coverage: $(GOVERALLS_TOOL)
 
 else
 
-uload-coverage:
+upload-coverage:
 	@echo Not uploading coverage during PR build.
 
 endif


### PR DESCRIPTION
Minor fix, opening PR in kastenhq to ensure CI can pass with the fix, then I'll open upstream.

Seems there's a typo in the makefile target `upload-coverage`, such that it is not found if Travis is running against a PR.