### PR TITLE
Include Client/Server basic model in Robustness Test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,7 @@ ifeq ($(KOPIA_EXE),)
 robustness-tests: dist-binary
 	FIO_DOCKER_IMAGE=$(FIO_DOCKER_TAG) \
 	KOPIA_EXE=$(KOPIA_INTEGRATION_EXE) \
-	$(GO_TEST) -count=1 github.com/kopia/kopia/tests/robustness/robustness_test $(TEST_FLAGS)
+	$(GO_TEST) -v -count=1 github.com/kopia/kopia/tests/robustness/robustness_test $(TEST_FLAGS)
 
 robustness-status: dist-binary
 	FIO_DOCKER_IMAGE=$(FIO_DOCKER_TAG) \
@@ -217,7 +217,7 @@ else
 # If KOPIA_EXE was provided, run the robustness tests and utils against that binary
 robustness-tests:
 	FIO_DOCKER_IMAGE=$(FIO_DOCKER_TAG) \
-	$(GO_TEST) -count=1 github.com/kopia/kopia/tests/robustness/robustness_test $(TEST_FLAGS)
+	$(GO_TEST) -v -count=1 github.com/kopia/kopia/tests/robustness/robustness_test $(TEST_FLAGS)
 
 robustness-status:
 	FIO_DOCKER_IMAGE=$(FIO_DOCKER_TAG) \
@@ -228,11 +228,11 @@ endif
 robustness-tool-tests: dist-binary
 	KOPIA_EXE=$(KOPIA_INTEGRATION_EXE) \
 	FIO_DOCKER_IMAGE=$(FIO_DOCKER_TAG) \
-	$(GO_TEST) -count=1 github.com/kopia/kopia/tests/tools/... github.com/kopia/kopia/tests/robustness/engine/... $(TEST_FLAGS)
+	$(GO_TEST) -v -count=1 github.com/kopia/kopia/tests/tools/... github.com/kopia/kopia/tests/robustness/engine/... $(TEST_FLAGS)
 
 stress-test:
 	KOPIA_LONG_STRESS_TEST=1 $(GO_TEST) -count=1 -timeout 200s github.com/kopia/kopia/tests/stress_test
-	$(GO_TEST) -count=1 -timeout 200s github.com/kopia/kopia/tests/repository_stress_test
+	$(GO_TEST) -v -count=1 -timeout 200s github.com/kopia/kopia/tests/repository_stress_test
 
 layering-test:
 ifneq ($(uname),Windows)

--- a/tests/robustness/engine/engine.go
+++ b/tests/robustness/engine/engine.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -197,9 +198,21 @@ func (e *Engine) Init(ctx context.Context, testRepoPath, metaRepoPath string) er
 	switch {
 	case os.Getenv(S3BucketNameEnvKey) != "":
 		bucketName := os.Getenv(S3BucketNameEnvKey)
+		fmt.Printf("Printing the S3 Bucket Name: %v\n", bucketName)
 		return e.InitS3(ctx, bucketName, testRepoPath, metaRepoPath)
 	default:
 		return e.InitFilesystem(ctx, testRepoPath, metaRepoPath)
+	}
+}
+
+func (e *Engine) InitWithServerClientModel(ctx context.Context, testRepoPath, metaRepoPath string) error {
+	switch {
+	case os.Getenv(S3BucketNameEnvKey) != "":
+		bucketName := os.Getenv(S3BucketNameEnvKey)
+		fmt.Printf("Printing the S3 Bucket Name: %v\n", bucketName)
+		return e.InitS3WithServer(ctx, bucketName, testRepoPath, metaRepoPath, "localhost:51515")
+	default:
+		return e.InitFilesystemWithServer(ctx, testRepoPath, metaRepoPath, "localhost:51515")
 	}
 }
 
@@ -263,4 +276,61 @@ func (e *Engine) init(ctx context.Context) error {
 	}
 
 	return e.Checker.VerifySnapshotMetadata()
+}
+
+func (e *Engine) InitS3WithServer(ctx context.Context, bucketName, testRepoPath, metaRepoPath, addr string) error {
+
+	fmt.Printf("Going Inside Create Server func\n")
+	err := e.MetaStore.ConnectOrCreateS3WithServer(addr, bucketName, metaRepoPath)
+	if err != nil {
+		fmt.Printf("Got error from Create Server func: %v\n", err)
+		return err
+	}
+	fmt.Printf("Got Outside Create Server func\n")
+
+	err = e.MetaStore.LoadMetadata()
+	if err != nil {
+		return err
+	}
+
+	err = e.TestRepo.ConnectOrCreateS3WithServer(addr, bucketName, testRepoPath)
+	if err != nil {
+		return err
+	}
+
+	_, _, err = e.TestRepo.Run("policy", "set", "--global", "--keep-latest", strconv.Itoa(1<<31-1))
+	if err != nil {
+		return err
+	}
+
+	err = e.Checker.VerifySnapshotMetadata()
+	if err != nil {
+		return err
+	}
+
+	snapIDs := e.Checker.GetLiveSnapIDs()
+	if len(snapIDs) > 0 {
+		randSnapID := snapIDs[rand.Intn(len(snapIDs))] //nolint:gosec
+
+		err = e.Checker.RestoreSnapshotToPath(ctx, randSnapID, e.FileWriter.LocalDataDir, os.Stdout)
+		if err != nil {
+			return err
+		}
+	}
+
+	return e.init(ctx)
+}
+
+func (e *Engine) InitFilesystemWithServer(ctx context.Context, testRepoPath, metaRepoPath, addr string) error {
+	err := e.MetaStore.ConnectOrCreateFilesystemWithServer(addr, metaRepoPath)
+	if err != nil {
+		return err
+	}
+
+	err = e.TestRepo.ConnectOrCreateFilesystemWithServer(addr, testRepoPath)
+	if err != nil {
+		return err
+	}
+
+	return e.init(ctx)
 }

--- a/tests/robustness/snap/snap.go
+++ b/tests/robustness/snap/snap.go
@@ -20,4 +20,6 @@ type Snapshotter interface {
 type RepoManager interface {
 	ConnectOrCreateS3(bucketName, pathPrefix string) error
 	ConnectOrCreateFilesystem(path string) error
+	ConnectOrCreateS3WithServer(bucketName, pathPrefix string, addr string) error
+	ConnectOrCreateFilesystemWithServer(path, addr string) error
 }

--- a/tests/robustness/snapmeta/kopia_meta.go
+++ b/tests/robustness/snapmeta/kopia_meta.go
@@ -70,6 +70,14 @@ func (store *kopiaMetadata) ConnectOrCreateFilesystem(path string) error {
 
 const metadataStoreFileName = "metadata-store-latest"
 
+func (store *kopiaMetadata) ConnectOrCreateS3WithServer(bucketName, pathPrefix, addr string) error {
+	return store.snap.ConnectOrCreateS3WithServer(bucketName, pathPrefix, addr)
+}
+
+func (store *kopiaMetadata) ConnectOrCreateFilesystemWithServer(path, addr string) error {
+	return store.snap.ConnectOrCreateFilesystemWithServer(path, addr)
+}
+
 // LoadMetadata implements the DataPersister interface, restores the latest
 // snapshot from the kopia repository and decodes its contents, populating
 // its metadata on the snapshots residing in the target test repository.

--- a/tests/tools/kopiarunner/kopia_snapshotter.go
+++ b/tests/tools/kopiarunner/kopia_snapshotter.go
@@ -108,13 +108,11 @@ func (ks *KopiaSnapshotter) ConnectOrCreateS3WithServer(serverAddr, bucketName, 
 	}
 
 	if err := ks.CreateServer(serverAddr); err != nil {
-		fmt.Printf("Error in Creating Server: %v\n", err)
 		return err
 	}
 
 	if err := ks.ConnectServer(serverAddr); err != nil {
-		fmt.Printf("Error in Connecting Server: %v\n", err)
-
+		fmt.Pr
 		return err
 	}
 
@@ -141,12 +139,10 @@ func (ks *KopiaSnapshotter) ConnectOrCreateFilesystemWithServer(repoPath, server
 	}
 
 	if err := ks.CreateServer(serverAddr); err != nil {
-		fmt.Printf("Error in Creating Server: %v\n", err)
 		return err
 	}
 
 	if err := ks.ConnectServer(serverAddr); err != nil {
-		fmt.Printf("Error in Connecting Server: %v\n", err)
 
 		return err
 	}
@@ -233,7 +229,6 @@ func (ks *KopiaSnapshotter) Run(args ...string) (stdout, stderr string, err erro
 
 func (ks *KopiaSnapshotter) CreateServer(addr string, args ...string) error {
 	args = append([]string{"server", "start", fmt.Sprintf("--address=%s", addr)}, args...)
-	fmt.Printf("Command for Creating to server: %v\n", args)
 
 	_, _, err := ks.Runner.RunServer(args...)
 	if err != nil {
@@ -249,7 +244,6 @@ func (ks *KopiaSnapshotter) CreateServer(addr string, args ...string) error {
 
 func (ks *KopiaSnapshotter) ConnectServer(addr string, args ...string) error {
 	args = append([]string{"repo", "connect", "server", fmt.Sprintf("--url=http://%s", addr)}, args...)
-	fmt.Printf("Command for Connecting to server: %v\n", args)
 	_, _, err := ks.Runner.Run(args...)
 
 	return err

--- a/tests/tools/kopiarunner/kopiarun.go
+++ b/tests/tools/kopiarunner/kopiarun.go
@@ -64,7 +64,6 @@ func (kr *Runner) Run(args ...string) (stdout, stderr string, err error) {
 	argsStr := strings.Join(args, " ")
 	log.Printf("running '%s %v'", kr.Exe, argsStr)
 	cmdArgs := append(append([]string(nil), kr.fixedArgs...), args...)
-
 	// nolint:gosec
 	c := exec.Command(kr.Exe, cmdArgs...)
 	c.Env = append(os.Environ(), kr.environment...)
@@ -73,8 +72,30 @@ func (kr *Runner) Run(args ...string) (stdout, stderr string, err error) {
 	c.Stderr = errOut
 
 	o, err := c.Output()
-
 	log.Printf("finished '%s %v' with err=%v and output:\nSTDOUT:\n%v\nSTDERR:\n%v", kr.Exe, argsStr, err, string(o), errOut.String())
+
+	return string(o), errOut.String(), err
+}
+
+// RunServer will execute the kopia command with the given args in background
+func (kr *Runner) RunServer(args ...string) (stdout, stderr string, err error) {
+	argsStr := strings.Join(args, " ")
+	log.Printf("running '%s %v'", kr.Exe, argsStr)
+	// nolint:gosec
+	cmdArgs := append(append([]string(nil), kr.fixedArgs...), args...)
+	// nolint:gosec
+	c := exec.Command(kr.Exe, cmdArgs...)
+	c.Env = append(os.Environ(), kr.environment...)
+
+	errOut := &bytes.Buffer{}
+	c.Stderr = errOut
+	err = c.Start()
+	if err != nil {
+		return "", "", err
+	}
+	//time.Sleep(10 * time.Second)
+	o, errOutput := c.Output()
+	log.Printf("finished '%s %v' with err=%v and output:\nSTDOUT:\n%v\nSTDERR:\n%v", kr.Exe, argsStr, errOutput, string(o), errOut.String())
 
 	return string(o), errOut.String(), err
 }


### PR DESCRIPTION
Changelog:
    - Added `-v` flags in MakeFile tests
    - Added methods to create server and client
    - Added un-exported methods to check if the server is running
    - Added function to initS3 with server as well as initFileSystem with server

Logs for Current Implementation: https://gist.github.com/rahulchheda/b9a8554a4990b8eaacf4c69023cc56a7

Signed-off-by: Rahul M Chheda <rchheda@infracloud.io>