### PR TITLE
Retry on TCP errors in S3 blob provider

### DIFF
--- a/repo/blob/s3/s3_storage.go
+++ b/repo/blob/s3/s3_storage.go
@@ -97,6 +97,11 @@ func isRetriableError(err error) bool {
 		return true
 	}
 
+	if strings.Contains(strings.ToLower(err.Error()), "tcp") {
+		// retry tcp transport errors, such as "connection reset"
+		return true
+	}
+
 	return false
 }
 

--- a/repo/blob/s3/s3_storage_test.go
+++ b/repo/blob/s3/s3_storage_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"crypto/sha1"
 	"fmt"
-	"log"
 	"net"
 	"net/http"
 	"os"
@@ -360,7 +359,7 @@ func createMinioSessionToken(t *testutil.RetriableT, kopiaUserName, kopiaUserPas
 		t.Fatalf("couldn't find aws creds in aws assume role response")
 	}
 
-	log.Printf("created session token with assume role: expiration: %s", result.Credentials.Expiration)
+	t.Logf("created session token with assume role: expiration: %s", result.Credentials.Expiration)
 
 	return *result.Credentials.AccessKeyId, *result.Credentials.SecretAccessKey, *result.Credentials.SessionToken
 }


### PR DESCRIPTION
Retry on errors of the form:

    read tcp xxx->yyy:443: read: connection reset by peer