### PR TITLE
Overwrite symlinks with optional flag - fix for #689

### DIFF
--- a/cli/command_restore.go
+++ b/cli/command_restore.go
@@ -56,6 +56,7 @@ var (
 	restoreTargetPath             = ""
 	restoreOverwriteDirectories   = true
 	restoreOverwriteFiles         = true
+	restoreOverwriteSymlinks      = true
 	restoreConsistentAttributes   = false
 	restoreMode                   = restoreModeAuto
 	restoreParallel               = 8
@@ -79,6 +80,7 @@ func addRestoreFlags(cmd *kingpin.CmdClause) {
 	cmd.Arg("target-path", "Path of the directory for the contents to be restored").Required().StringVar(&restoreTargetPath)
 	cmd.Flag("overwrite-directories", "Overwrite existing directories").BoolVar(&restoreOverwriteDirectories)
 	cmd.Flag("overwrite-files", "Specifies whether or not to overwrite already existing files").BoolVar(&restoreOverwriteFiles)
+	cmd.Flag("overwrite-symlinks", "Specifies whether or not to overwrite already existing symlinks").BoolVar(&restoreOverwriteSymlinks)
 	cmd.Flag("consistent-attributes", "When multiple snapshots match, fail if they have inconsistent attributes").Envar("KOPIA_RESTORE_CONSISTENT_ATTRIBUTES").BoolVar(&restoreConsistentAttributes)
 	cmd.Flag("mode", "Override restore mode").EnumVar(&restoreMode, restoreModeAuto, restoreModeLocal, restoreModeZip, restoreModeZipNoCompress, restoreModeTar, restoreModeTgz)
 	cmd.Flag("parallel", "Restore parallelism (1=disable)").IntVar(&restoreParallel)
@@ -101,6 +103,7 @@ func restoreOutput(ctx context.Context) (restore.Output, error) {
 			TargetPath:             p,
 			OverwriteDirectories:   restoreOverwriteDirectories,
 			OverwriteFiles:         restoreOverwriteFiles,
+			OverwriteSymlinks:      restoreOverwriteSymlinks,
 			IgnorePermissionErrors: restoreIgnorePermissionErrors,
 			SkipOwners:             restoreSkipOwners,
 			SkipPermissions:        restoreSkipPermissions,

--- a/snapshot/restore/local_fs_output.go
+++ b/snapshot/restore/local_fs_output.go
@@ -110,7 +110,7 @@ func (o *FilesystemOutput) CreateSymlink(ctx context.Context, relativePath strin
 	case os.IsNotExist(err): // Proceed to symlink creation
 	case err != nil:
 		return errors.Wrap(err, "lstat error at symlink path")
-	case stat.Mode() == os.ModeSymlink:
+	case fileIsSymlink(stat):
 		// Throw error if we are not overwriting symlinks
 		if !o.OverwriteSymlinks {
 			return errors.Errorf("will not overwrite existing symlink")
@@ -133,6 +133,10 @@ func (o *FilesystemOutput) CreateSymlink(ctx context.Context, relativePath strin
 	}
 
 	return nil
+}
+
+func fileIsSymlink(stat os.FileInfo) bool {
+	return stat.Mode()&os.ModeSymlink != 0
 }
 
 // set permission, modification time and user/group ids on targetPath.

--- a/tests/end_to_end_test/restore_test.go
+++ b/tests/end_to_end_test/restore_test.go
@@ -189,7 +189,7 @@ func TestSnapshotRestore(t *testing.T) {
 	e.RunAndExpectSuccess(t, "snapshot", "restore", rootID+"/subdir1", restoreByOIDSubdir)
 	verifyFileMode(t, restoreByOIDSubdir, os.ModeDir|os.FileMode(overriddenDirPermissions))
 
-	// Check restore idempotency. Repeat the restore
+	// Check restore idempotency. Repeat the restore into the already-restored directory.
 	e.RunAndExpectSuccess(t, "snapshot", "restore", rootID+"/subdir1", restoreByOIDSubdir)
 	verifyFileMode(t, restoreByOIDSubdir, os.ModeDir|os.FileMode(overriddenDirPermissions))
 

--- a/tests/end_to_end_test/restore_test.go
+++ b/tests/end_to_end_test/restore_test.go
@@ -276,18 +276,12 @@ func TestSnapshotRestore(t *testing.T) {
 		t.Fatalf("unexpected stat() results on output.zip directory %v %v", st, err)
 	}
 
-	// restoreFailDir := t.TempDir()
-
 	// Attempt to restore snapshot with an already-existing target directory
 	// It should fail because the directory is not empty
-	// _ = os.MkdirAll(restoreFailDir, 0o700)
-
 	e.RunAndExpectFailure(t, "snapshot", "restore", "--no-overwrite-directories", snapID, restoreDir)
 
 	// Attempt to restore snapshot with an already-existing target directory
 	// It should fail because target files already exist
-	// _ = os.MkdirAll(restoreFailDir, 0o700)
-
 	e.RunAndExpectFailure(t, "snapshot", "restore", "--no-overwrite-files", snapID, restoreDir)
 
 	// Attempt to restore snapshot with an already-existing target directory
@@ -327,6 +321,49 @@ func TestRestoreSymlinkWithoutTarget(t *testing.T) {
 
 	restoredDir := t.TempDir()
 	e.RunAndExpectSuccess(t, "snapshot", "restore", "--no-ignore-permission-errors", snapID, restoredDir)
+}
+
+func TestRestoreSymlinkWithNonSymlinkOverwrite(t *testing.T) {
+	t.Parallel()
+
+	e := testenv.NewCLITest(t)
+	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
+
+	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
+
+	source := t.TempDir()
+
+	testLinkName := "lnk"
+	lnkPath := filepath.Join(source, testLinkName)
+
+	if err := os.Symlink(".no-such-file", lnkPath); err != nil {
+		t.Fatal(err)
+	}
+
+	e.RunAndExpectSuccess(t, "snapshot", "create", source)
+
+	// obtain snapshot root id and use it for restore
+	si := e.ListSnapshotsAndExpectSuccess(t, source)
+	if got, want := len(si), 1; got != want {
+		t.Fatalf("got %v sources, wanted %v", got, want)
+	}
+
+	if got, want := len(si[0].Snapshots), 1; got != want {
+		t.Fatalf("got %v snapshots, wanted %v", got, want)
+	}
+
+	snapID := si[0].Snapshots[0].SnapshotID
+
+	restoreDir := t.TempDir()
+
+	// Make a directory containing a non-symlink entry named the same as the link captured by the snapshot
+	dirWithLinkName := filepath.Join(restoreDir, testLinkName)
+
+	if err := os.Mkdir(dirWithLinkName, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	e.RunAndExpectFailure(t, "snapshot", "restore", snapID, restoreDir)
 }
 
 func TestRestoreSnapshotOfSingleFile(t *testing.T) {

--- a/tests/end_to_end_test/restore_test.go
+++ b/tests/end_to_end_test/restore_test.go
@@ -189,6 +189,10 @@ func TestSnapshotRestore(t *testing.T) {
 	e.RunAndExpectSuccess(t, "snapshot", "restore", rootID+"/subdir1", restoreByOIDSubdir)
 	verifyFileMode(t, restoreByOIDSubdir, os.ModeDir|os.FileMode(overriddenDirPermissions))
 
+	// Check restore idempotency. Repeat the restore
+	e.RunAndExpectSuccess(t, "snapshot", "restore", rootID+"/subdir1", restoreByOIDSubdir)
+	verifyFileMode(t, restoreByOIDSubdir, os.ModeDir|os.FileMode(overriddenDirPermissions))
+
 	restoreByOIDSubdir2 := t.TempDir()
 
 	originalDirInfo, err := os.Stat(restoreByOIDSubdir2)


### PR DESCRIPTION
Add symlink overwrite behavior to fix `file exists` error when restoring a symlink that already exists

Before creating the restored symlink, check `os.Lstat`:
- If it returns an error indicating the file does not exist, proceed to symlink creation
- If it returns any other error, propagate the error up to the caller
- If the fileInfo indicates the entry is a symlink AND `--no-overwrite-symlinks` was set in the restore command, propagate an error to the caller
- If `--no-overwrite-symlinks` was NOT set, remove the existing symlink before proceeding to symlink creation
- Else the file exists but it is not of type symlink. Halt the operation and propagate an error indicating we tried to restore a symlink over a file system entry that already existed but was not a symlink.


Added case to `TestSnapshotRestore` that fails before this fix and succeeds after this fix. The case is simply to restore the same snapshot into the same directory twice in a row, where the second restore will be on top of the first one.

Added test case to ensure `--no-overwrite-symlinks` throws an error as expected if restoring into a directory where a symlink already exists at the path symlink creation is attempted.

Added test case to ensure that the restore operation fails if a symlink is needed to be restored to the same path as an existing non-symlink filesystem entry with the same name.