### PR TITLE
Refactored the snaphotter and persister initialization logic out of the robustness engine.

### DIFF
--- a/tests/robustness/comparer.go
+++ b/tests/robustness/comparer.go
@@ -8,6 +8,6 @@ import (
 // Comparer describes an interface that gathers state data on a provided
 // path, and compares that data to the state on another path.
 type Comparer interface {
-	Gather(ctx context.Context, path string) ([]byte, error)
-	Compare(ctx context.Context, path string, data []byte, reportOut io.Writer) error
+	Gather(ctx context.Context, path string, opts map[string]string) ([]byte, error)
+	Compare(ctx context.Context, path string, data []byte, reportOut io.Writer, opts map[string]string) error
 }

--- a/tests/robustness/engine/action.go
+++ b/tests/robustness/engine/action.go
@@ -175,7 +175,7 @@ var actions = map[ActionKey]Action{
 			log.Printf("Creating snapshot of root directory %s", e.FileWriter.DataDirectory())
 
 			ctx := context.TODO()
-			snapID, err := e.Checker.TakeSnapshot(ctx, e.FileWriter.DataDirectory())
+			snapID, err := e.Checker.TakeSnapshot(ctx, e.FileWriter.DataDirectory(), opts)
 
 			setLogEntryCmdOpts(l, map[string]string{
 				"snap-dir": e.FileWriter.DataDirectory(),
@@ -201,7 +201,7 @@ var actions = map[ActionKey]Action{
 			ctx := context.Background()
 			b := &bytes.Buffer{}
 
-			err = e.Checker.RestoreSnapshot(ctx, snapID, b)
+			err = e.Checker.RestoreSnapshot(ctx, snapID, b, opts)
 			if err != nil {
 				log.Print(b.String())
 			}
@@ -221,13 +221,13 @@ var actions = map[ActionKey]Action{
 			setLogEntryCmdOpts(l, map[string]string{"snapID": snapID})
 
 			ctx := context.Background()
-			err = e.Checker.DeleteSnapshot(ctx, snapID)
+			err = e.Checker.DeleteSnapshot(ctx, snapID, opts)
 			return nil, err
 		},
 	},
 	GCActionKey: {
 		f: func(e *Engine, opts map[string]string, l *LogEntry) (out map[string]string, err error) {
-			return nil, e.TestRepo.RunGC()
+			return nil, e.TestRepo.RunGC(opts)
 		},
 	},
 	WriteRandomFilesActionKey: {
@@ -266,7 +266,7 @@ var actions = map[ActionKey]Action{
 			setLogEntryCmdOpts(l, map[string]string{"snapID": snapID})
 
 			b := &bytes.Buffer{}
-			err = e.Checker.RestoreSnapshotToPath(context.Background(), snapID, e.FileWriter.DataDirectory(), b)
+			err = e.Checker.RestoreSnapshotToPath(context.Background(), snapID, e.FileWriter.DataDirectory(), b, opts)
 			if err != nil {
 				log.Print(b.String())
 				return nil, err

--- a/tests/robustness/engine/engine.go
+++ b/tests/robustness/engine/engine.go
@@ -178,8 +178,6 @@ func (e *Engine) cleanComponents() {
 			f()
 		}
 	}
-
-	os.RemoveAll(e.baseDirPath) //nolint:errcheck
 }
 
 // Init initializes the Engine and performs a consistency check.

--- a/tests/robustness/engine/engine_test.go
+++ b/tests/robustness/engine/engine_test.go
@@ -45,6 +45,9 @@ var (
 )
 
 func TestEngineWritefilesBasicFS(t *testing.T) {
+	os.Setenv(snapmeta.EngineModeEnvKey, snapmeta.EngineModeBasic)
+	os.Setenv(snapmeta.S3BucketNameEnvKey, "")
+
 	eng, err := NewEngine("")
 	if errors.Is(err, kopiarunner.ErrExeVariableNotSet) || errors.Is(err, fio.ErrEnvNotSet) {
 		t.Skip(err)
@@ -60,7 +63,7 @@ func TestEngineWritefilesBasicFS(t *testing.T) {
 	}()
 
 	ctx := context.TODO()
-	err = eng.InitFilesystem(ctx, fsDataRepoPath, fsMetadataRepoPath)
+	err = eng.Init(ctx, fsDataRepoPath, fsMetadataRepoPath)
 	testenv.AssertNoError(t, err)
 
 	fileSize := int64(256 * 1024)
@@ -157,6 +160,9 @@ func TestWriteFilesBasicS3(t *testing.T) {
 	bucketName, cleanupCB := makeTempS3Bucket(t)
 	defer cleanupCB()
 
+	os.Setenv(snapmeta.EngineModeEnvKey, snapmeta.EngineModeBasic)
+	os.Setenv(snapmeta.S3BucketNameEnvKey, bucketName)
+
 	eng, err := NewEngine("")
 	if errors.Is(err, kopiarunner.ErrExeVariableNotSet) || errors.Is(err, fio.ErrEnvNotSet) {
 		t.Skip(err)
@@ -170,7 +176,7 @@ func TestWriteFilesBasicS3(t *testing.T) {
 	}()
 
 	ctx := context.TODO()
-	err = eng.InitS3(ctx, bucketName, s3DataRepoPath, s3MetadataRepoPath)
+	err = eng.Init(ctx, s3DataRepoPath, s3MetadataRepoPath)
 	testenv.AssertNoError(t, err)
 
 	fileSize := int64(256 * 1024)
@@ -199,6 +205,9 @@ func TestDeleteSnapshotS3(t *testing.T) {
 	bucketName, cleanupCB := makeTempS3Bucket(t)
 	defer cleanupCB()
 
+	os.Setenv(snapmeta.EngineModeEnvKey, snapmeta.EngineModeBasic)
+	os.Setenv(snapmeta.S3BucketNameEnvKey, bucketName)
+
 	eng, err := NewEngine("")
 	if errors.Is(err, kopiarunner.ErrExeVariableNotSet) || errors.Is(err, fio.ErrEnvNotSet) {
 		t.Skip(err)
@@ -212,7 +221,7 @@ func TestDeleteSnapshotS3(t *testing.T) {
 	}()
 
 	ctx := context.TODO()
-	err = eng.InitS3(ctx, bucketName, s3DataRepoPath, s3MetadataRepoPath)
+	err = eng.Init(ctx, s3DataRepoPath, s3MetadataRepoPath)
 	testenv.AssertNoError(t, err)
 
 	fileSize := int64(256 * 1024)
@@ -242,6 +251,9 @@ func TestSnapshotVerificationFail(t *testing.T) {
 	bucketName, cleanupCB := makeTempS3Bucket(t)
 	defer cleanupCB()
 
+	os.Setenv(snapmeta.EngineModeEnvKey, snapmeta.EngineModeBasic)
+	os.Setenv(snapmeta.S3BucketNameEnvKey, bucketName)
+
 	eng, err := NewEngine("")
 	if errors.Is(err, kopiarunner.ErrExeVariableNotSet) || errors.Is(err, fio.ErrEnvNotSet) {
 		t.Skip(err)
@@ -255,7 +267,7 @@ func TestSnapshotVerificationFail(t *testing.T) {
 	}()
 
 	ctx := context.TODO()
-	err = eng.InitS3(ctx, bucketName, s3DataRepoPath, s3MetadataRepoPath)
+	err = eng.Init(ctx, s3DataRepoPath, s3MetadataRepoPath)
 	testenv.AssertNoError(t, err)
 
 	// Perform writes
@@ -303,6 +315,9 @@ func TestSnapshotVerificationFail(t *testing.T) {
 }
 
 func TestDataPersistency(t *testing.T) {
+	os.Setenv(snapmeta.EngineModeEnvKey, snapmeta.EngineModeBasic)
+	os.Setenv(snapmeta.S3BucketNameEnvKey, "")
+
 	tempDir, err := ioutil.TempDir("", "")
 	testenv.AssertNoError(t, err)
 
@@ -324,7 +339,7 @@ func TestDataPersistency(t *testing.T) {
 	metadataRepoPath := filepath.Join(tempDir, "metadata-repo-")
 
 	ctx := context.TODO()
-	err = eng.InitFilesystem(ctx, dataRepoPath, metadataRepoPath)
+	err = eng.Init(ctx, dataRepoPath, metadataRepoPath)
 	testenv.AssertNoError(t, err)
 
 	// Perform writes
@@ -358,7 +373,7 @@ func TestDataPersistency(t *testing.T) {
 	// expect that the snapshot taken above will be found in metadata,
 	// and the data will be chosen to be restored to this engine's DataDir
 	// as a starting point.
-	err = eng2.InitFilesystem(ctx, dataRepoPath, metadataRepoPath)
+	err = eng2.Init(ctx, dataRepoPath, metadataRepoPath)
 	testenv.AssertNoError(t, err)
 
 	fioRunner2 := engineFioRunner(t, eng2)
@@ -466,6 +481,9 @@ func TestPickActionWeighted(t *testing.T) {
 }
 
 func TestActionsFilesystem(t *testing.T) {
+	os.Setenv(snapmeta.EngineModeEnvKey, snapmeta.EngineModeBasic)
+	os.Setenv(snapmeta.S3BucketNameEnvKey, "")
+
 	eng, err := NewEngine("")
 	if errors.Is(err, kopiarunner.ErrExeVariableNotSet) || errors.Is(err, fio.ErrEnvNotSet) {
 		t.Skip(err)
@@ -481,7 +499,7 @@ func TestActionsFilesystem(t *testing.T) {
 	}()
 
 	ctx := context.TODO()
-	err = eng.InitFilesystem(ctx, fsDataRepoPath, fsMetadataRepoPath)
+	err = eng.Init(ctx, fsDataRepoPath, fsMetadataRepoPath)
 	testenv.AssertNoError(t, err)
 
 	actionOpts := ActionOpts{
@@ -511,6 +529,9 @@ func TestActionsS3(t *testing.T) {
 	bucketName, cleanupCB := makeTempS3Bucket(t)
 	defer cleanupCB()
 
+	os.Setenv(snapmeta.EngineModeEnvKey, snapmeta.EngineModeBasic)
+	os.Setenv(snapmeta.S3BucketNameEnvKey, bucketName)
+
 	eng, err := NewEngine("")
 	if errors.Is(err, kopiarunner.ErrExeVariableNotSet) || errors.Is(err, fio.ErrEnvNotSet) {
 		t.Skip(err)
@@ -524,7 +545,7 @@ func TestActionsS3(t *testing.T) {
 	}()
 
 	ctx := context.TODO()
-	err = eng.InitS3(ctx, bucketName, s3DataRepoPath, s3MetadataRepoPath)
+	err = eng.Init(ctx, s3DataRepoPath, s3MetadataRepoPath)
 	testenv.AssertNoError(t, err)
 
 	actionOpts := ActionOpts{
@@ -558,6 +579,9 @@ func TestIOLimitPerWriteAction(t *testing.T) {
 	// set to 1 MB.
 	const timeout = 10 * time.Second
 
+	os.Setenv(snapmeta.EngineModeEnvKey, snapmeta.EngineModeBasic)
+	os.Setenv(snapmeta.S3BucketNameEnvKey, "")
+
 	eng, err := NewEngine("")
 	if errors.Is(err, kopiarunner.ErrExeVariableNotSet) || errors.Is(err, fio.ErrEnvNotSet) {
 		t.Skip(err)
@@ -573,7 +597,7 @@ func TestIOLimitPerWriteAction(t *testing.T) {
 	}()
 
 	ctx := context.TODO()
-	err = eng.InitFilesystem(ctx, fsDataRepoPath, fsMetadataRepoPath)
+	err = eng.Init(ctx, fsDataRepoPath, fsMetadataRepoPath)
 	testenv.AssertNoError(t, err)
 
 	actionOpts := ActionOpts{
@@ -613,7 +637,7 @@ func TestStatsPersist(t *testing.T) {
 
 	defer os.RemoveAll(tmpDir)
 
-	snapStore, err := snapmeta.New(tmpDir)
+	snapStore, err := snapmeta.NewPersister(tmpDir)
 	if errors.Is(err, kopiarunner.ErrExeVariableNotSet) {
 		t.Skip(err)
 	}
@@ -644,13 +668,13 @@ func TestStatsPersist(t *testing.T) {
 		},
 	}
 
-	err = eng.SaveStats()
+	err = eng.saveStats()
 	testenv.AssertNoError(t, err)
 
 	err = eng.MetaStore.FlushMetadata()
 	testenv.AssertNoError(t, err)
 
-	snapStoreNew, err := snapmeta.New(tmpDir)
+	snapStoreNew, err := snapmeta.NewPersister(tmpDir)
 	testenv.AssertNoError(t, err)
 
 	// Connect to the same metadata store
@@ -664,7 +688,7 @@ func TestStatsPersist(t *testing.T) {
 		MetaStore: snapStoreNew,
 	}
 
-	err = engNew.LoadStats()
+	err = engNew.loadStats()
 	testenv.AssertNoError(t, err)
 
 	if got, want := engNew.Stats(), eng.Stats(); got != want {
@@ -681,7 +705,7 @@ func TestLogsPersist(t *testing.T) {
 
 	defer os.RemoveAll(tmpDir)
 
-	snapStore, err := snapmeta.New(tmpDir)
+	snapStore, err := snapmeta.NewPersister(tmpDir)
 	if errors.Is(err, kopiarunner.ErrExeVariableNotSet) {
 		t.Skip(err)
 	}
@@ -714,13 +738,13 @@ func TestLogsPersist(t *testing.T) {
 		EngineLog: log,
 	}
 
-	err = eng.SaveLog()
+	err = eng.saveLog()
 	testenv.AssertNoError(t, err)
 
 	err = eng.MetaStore.FlushMetadata()
 	testenv.AssertNoError(t, err)
 
-	snapStoreNew, err := snapmeta.New(tmpDir)
+	snapStoreNew, err := snapmeta.NewPersister(tmpDir)
 	testenv.AssertNoError(t, err)
 
 	// Connect to the same metadata store
@@ -734,7 +758,7 @@ func TestLogsPersist(t *testing.T) {
 		MetaStore: snapStoreNew,
 	}
 
-	err = engNew.LoadLog()
+	err = engNew.loadLog()
 	testenv.AssertNoError(t, err)
 
 	if got, want := engNew.EngineLog.String(), eng.EngineLog.String(); got != want {

--- a/tests/robustness/engine/metadata.go
+++ b/tests/robustness/engine/metadata.go
@@ -15,8 +15,8 @@ const (
 	engineLogsStoreKey  = "engine-logs"
 )
 
-// SaveLog saves the engine Log in the metadata store.
-func (e *Engine) SaveLog() error {
+// saveLog saves the engine Log in the metadata store.
+func (e *Engine) saveLog() error {
 	b, err := json.Marshal(e.EngineLog)
 	if err != nil {
 		return err
@@ -25,8 +25,8 @@ func (e *Engine) SaveLog() error {
 	return e.MetaStore.Store(engineLogsStoreKey, b)
 }
 
-// LoadLog loads the engine log from the metadata store.
-func (e *Engine) LoadLog() error {
+// loadLog loads the engine log from the metadata store.
+func (e *Engine) loadLog() error {
 	b, err := e.MetaStore.Load(engineLogsStoreKey)
 	if err != nil {
 		if errors.Is(err, snapmeta.ErrKeyNotFound) {
@@ -47,8 +47,8 @@ func (e *Engine) LoadLog() error {
 	return err
 }
 
-// SaveStats saves the engine Stats in the metadata store.
-func (e *Engine) SaveStats() error {
+// saveStats saves the engine Stats in the metadata store.
+func (e *Engine) saveStats() error {
 	cumulStatRaw, err := json.Marshal(e.CumulativeStats)
 	if err != nil {
 		return err
@@ -57,8 +57,8 @@ func (e *Engine) SaveStats() error {
 	return e.MetaStore.Store(engineStatsStoreKey, cumulStatRaw)
 }
 
-// LoadStats loads the engine Stats from the metadata store.
-func (e *Engine) LoadStats() error {
+// loadStats loads the engine Stats from the metadata store.
+func (e *Engine) loadStats() error {
 	b, err := e.MetaStore.Load(engineStatsStoreKey)
 	if err != nil {
 		if errors.Is(err, snapmeta.ErrKeyNotFound) {

--- a/tests/robustness/filewriter.go
+++ b/tests/robustness/filewriter.go
@@ -2,10 +2,6 @@ package robustness
 
 // FileWriter is an interface used for filesystem related actions.
 type FileWriter interface {
-	// Cleanup is called prior to termination.
-	// TBD: Will be removed when initialization refactored.
-	Cleanup()
-
 	// DataDirectory returns the absolute path of the data directory configured.
 	DataDirectory() string
 

--- a/tests/robustness/fiofilewriter/fio_filewriter.go
+++ b/tests/robustness/fiofilewriter/fio_filewriter.go
@@ -46,7 +46,7 @@ const (
 
 // New returns a FileWriter based on FIO.
 // See tests/tools/fio for configuration details.
-func New() (robustness.FileWriter, error) {
+func New() (*FileWriter, error) {
 	runner, err := fio.NewRunner()
 	if err != nil {
 		return nil, err
@@ -59,6 +59,8 @@ func New() (robustness.FileWriter, error) {
 type FileWriter struct {
 	Runner *fio.Runner
 }
+
+var _ robustness.FileWriter = (*FileWriter)(nil)
 
 // DataDirectory returns the data directory configured.
 // See tests/tools/fio for details.

--- a/tests/robustness/persister.go
+++ b/tests/robustness/persister.go
@@ -20,7 +20,6 @@ type Indexer interface {
 // to, and load it again, from a repository.
 type Persister interface {
 	Store
-	RepoManager // TBD: may not be needed once initialization refactored
 	LoadMetadata() error
 	FlushMetadata() error
 	GetPersistDir() string

--- a/tests/robustness/persister.go
+++ b/tests/robustness/persister.go
@@ -23,5 +23,4 @@ type Persister interface {
 	LoadMetadata() error
 	FlushMetadata() error
 	GetPersistDir() string
-	Cleanup()
 }

--- a/tests/robustness/robustness_test/main_test.go
+++ b/tests/robustness/robustness_test/main_test.go
@@ -6,19 +6,32 @@ import (
 	"context"
 	"errors"
 	"flag"
+	"io/ioutil"
 	"log"
 	"os"
 	"path"
+	"syscall"
 	"testing"
 	"time"
 
 	"github.com/kopia/kopia/tests/robustness"
 	"github.com/kopia/kopia/tests/robustness/engine"
+	"github.com/kopia/kopia/tests/robustness/fiofilewriter"
+	"github.com/kopia/kopia/tests/robustness/snapmeta"
 	"github.com/kopia/kopia/tests/tools/fio"
+	"github.com/kopia/kopia/tests/tools/fswalker"
 	"github.com/kopia/kopia/tests/tools/kopiarunner"
 )
 
-var eng *engine.Engine
+// test globals.
+var (
+	eng              *engine.Engine
+	fioFileWriter    *fiofilewriter.FileWriter
+	kopiaSnapshotter *snapmeta.KopiaSnapshotter
+	kopiaPersister   *snapmeta.KopiaPersister
+	fsComparer       *fswalker.WalkCompare
+	baseDir          string
+)
 
 const (
 	dataSubPath     = "robustness-data"
@@ -34,50 +47,147 @@ var (
 func TestMain(m *testing.M) {
 	flag.Parse()
 
-	var err error
-
-	eng, err = engine.NewEngine("")
-
-	switch {
-	case errors.Is(err, kopiarunner.ErrExeVariableNotSet):
-		log.Println("Skipping robustness tests because KOPIA_EXE is not set")
-		os.Exit(0)
-	case errors.Is(err, fio.ErrEnvNotSet):
-		log.Println("Skipping robustness tests because FIO environment is not set")
-		os.Exit(0)
-	case err != nil:
-		log.Fatalln("error on engine creation:", err)
-	}
-
 	dataRepoPath := path.Join(*repoPathPrefix, dataSubPath)
 	metadataRepoPath := path.Join(*repoPathPrefix, metadataSubPath)
 
-	// Try to reconcile metadata if it is out of sync with the repo state
-	eng.Checker.RecoveryMode = true
+	var err error
+
+	// create the work arena
+	baseDir, err = ioutil.TempDir("", "engine-data-")
+	if err != nil {
+		log.Fatalln("error creating temp dir:", err)
+	}
+
+	// Create the interfaces
+	fioFileWriter = getFioFileWriter()
+	kopiaSnapshotter = getKopiaSnapshotter(baseDir, dataRepoPath)
+	kopiaPersister = getKopiaPersister(baseDir, metadataRepoPath)
+	fsComparer = fswalker.NewWalkCompare()
+
+	// Create the engine
+	args := &engine.Args{
+		MetaStore:        kopiaPersister,
+		TestRepo:         kopiaSnapshotter,
+		Validator:        fsComparer,
+		FileWriter:       fioFileWriter,
+		WorkingDir:       baseDir,
+		SyncRepositories: true,
+	}
+	if eng, err = engine.New(args); err != nil {
+		logFatalln("error on engine creation:", err)
+	}
 
 	// Initialize the engine, connecting it to the repositories
-	err = eng.Init(context.Background(), dataRepoPath, metadataRepoPath)
+	err = eng.Init(context.Background())
 	if err != nil {
-		// Clean the temporary dirs from the file system, don't write out the
-		// metadata, in case there was an issue loading it
-		eng.CleanComponents()
-		log.Fatalln("error initializing engine for S3:", err)
+		// Don't write out the metadata, in case there was an issue loading it
+		logFatalln("error initializing engine for S3:", err)
 	}
 
 	// Restore a random snapshot into the data directory
 	_, err = eng.ExecAction(engine.RestoreIntoDataDirectoryActionKey, nil)
 	if err != nil && !errors.Is(err, robustness.ErrNoOp) {
-		eng.Cleanup()
-		log.Fatalln("error restoring into the data directory:", err)
+		eng.Shutdown()
+		logFatalln("error restoring into the data directory:", err)
 	}
 
 	result := m.Run()
 
-	err = eng.Cleanup()
+	err = eng.Shutdown()
+
+	cleanup()
+
 	if err != nil {
 		log.Printf("error cleaning up the engine: %s\n", err.Error())
 		os.Exit(2)
 	}
 
 	os.Exit(result)
+}
+
+// cleanup exists as a separate function because os.Exit(),
+// used directly or indirectly via log.Fatal, does not invoke
+// deferred functions.
+func cleanup() {
+	if kopiaPersister != nil {
+		kopiaPersister.Cleanup()
+	}
+
+	if kopiaSnapshotter != nil {
+		if sc := kopiaSnapshotter.ServerCmd(); sc != nil {
+			if err := sc.Process.Signal(syscall.SIGTERM); err != nil {
+				log.Println("Failed to send termination signal to kopia server process:", err)
+			}
+		}
+
+		kopiaSnapshotter.Cleanup()
+	}
+
+	if fioFileWriter != nil {
+		fioFileWriter.Cleanup()
+	}
+
+	if baseDir != "" {
+		os.RemoveAll(baseDir)
+	}
+}
+
+func logFatalln(v ...interface{}) {
+	cleanup()
+	log.Fatalln(v...)
+}
+
+func logPrintExit(rc int, v ...interface{}) {
+	cleanup()
+	log.Print(v...)
+	os.Exit(rc)
+}
+
+func getFioFileWriter() *fiofilewriter.FileWriter {
+	fw, err := fiofilewriter.New()
+	if err != nil {
+		if errors.Is(err, fio.ErrEnvNotSet) {
+			logPrintExit(0, "Skipping robustness tests because FIO environment is not set")
+		}
+
+		log.Fatalln("error creating fio FileWriter:", err)
+	}
+
+	return fw
+}
+
+func getKopiaSnapshotter(baseDir, repoPath string) *snapmeta.KopiaSnapshotter {
+	ks, err := snapmeta.NewSnapshotter(baseDir)
+	if err != nil {
+		if errors.Is(err, kopiarunner.ErrExeVariableNotSet) {
+			logPrintExit(0, "Skipping robustness tests because KOPIA_EXE is not set")
+		}
+
+		logFatalln("error creating kopia Snapshotter:", err)
+	}
+
+	if err = ks.ConnectOrCreateRepo(repoPath); err != nil {
+		ks.Cleanup()
+		logFatalln("error initializing kopia Snapshotter:", err)
+	}
+
+	return ks
+}
+
+func getKopiaPersister(baseDir, repoPath string) *snapmeta.KopiaPersister {
+	kp, err := snapmeta.NewPersister(baseDir)
+	if err != nil {
+		if errors.Is(err, kopiarunner.ErrExeVariableNotSet) {
+			logPrintExit(0, "Skipping robustness tests because KOPIA_EXE is not set")
+		}
+
+		logFatalln("error creating kopia Persister:", err)
+	}
+
+	if err = kp.ConnectOrCreateRepo(repoPath); err != nil {
+		kp.Cleanup()
+		logFatalln("error initializing kopia Persister:", err)
+	}
+
+	return kp
 }

--- a/tests/robustness/snapmeta/kopia_connector.go
+++ b/tests/robustness/snapmeta/kopia_connector.go
@@ -1,0 +1,104 @@
+package snapmeta
+
+import (
+	"os"
+	"os/exec"
+
+	"github.com/kopia/kopia/tests/tools/kopiarunner"
+)
+
+const (
+	// S3BucketNameEnvKey is the environment variable required to connect to a repo on S3.
+	S3BucketNameEnvKey = "S3_BUCKET_NAME"
+	// EngineModeEnvKey is the environment variable required to switch between basic and server/client model.
+	EngineModeEnvKey = "ENGINE_MODE"
+	// EngineModeBasic is a constant used to check the engineMode.
+	EngineModeBasic = "BASIC"
+	// EngineModeServer is a constant used to check the engineMode.
+	EngineModeServer = "SERVER"
+	// defaultAddr is used for setting the address of Kopia Server.
+	defaultAddr = "localhost:51515"
+)
+
+// kopiaConnector is a base type for Persister and Snapshotter.
+// It provides a kopiarunner.KopiaSnapshotter and common initialization
+// behavior based on the values of the EngineModeEnvKey and
+// S3BucketNameEnvKey environment variables.
+//
+// Derived types can customize the initialization behavior by overriding
+// the default handler functions.
+type kopiaConnector struct {
+	// properties set by initializeConnector()
+	snap                       *kopiarunner.KopiaSnapshotter
+	initS3Fn                   func(repoPath, bucketName string) error
+	initS3WithServerFn         func(repoPath, bucketName, addr string) error
+	initFilesystemFn           func(repoPath string) error
+	initFilesystemWithServerFn func(repoPath, addr string) error
+
+	// properties that may be set by connectOrCreateRepo()
+	serverCmd *exec.Cmd
+}
+
+// initializeConnector initializes the connector object and enables use of the
+// connectOrCreateRepo method.
+func (ki *kopiaConnector) initializeConnector(baseDirPath string) error {
+	snap, err := kopiarunner.NewKopiaSnapshotter(baseDirPath)
+	if err != nil {
+		return err
+	}
+
+	ki.snap = snap
+	ki.initS3Fn = ki.initS3
+	ki.initFilesystemFn = ki.initFilesystem
+	ki.initS3WithServerFn = ki.initS3WithServer
+	ki.initFilesystemWithServerFn = ki.initFilesystemWithServer
+
+	return nil
+}
+
+// connectOrCreateRepo makes the connector ready for use.
+// It invokes the appropriate initialization routine based on the environment variables set.
+func (ki *kopiaConnector) connectOrCreateRepo(repoPath string) error {
+	bucketName := os.Getenv(S3BucketNameEnvKey)
+	engineMode := os.Getenv(EngineModeEnvKey)
+
+	switch {
+	case bucketName != "" && engineMode == EngineModeBasic:
+		return ki.initS3Fn(repoPath, bucketName)
+
+	case bucketName != "" && engineMode == EngineModeServer:
+		return ki.initS3WithServerFn(repoPath, bucketName, defaultAddr)
+
+	case bucketName == "" && engineMode == EngineModeServer:
+		return ki.initFilesystemWithServerFn(repoPath, defaultAddr)
+
+	default:
+		return ki.initFilesystemFn(repoPath)
+	}
+}
+
+// initS3 initializes basic mode with an S3 repository.
+func (ki *kopiaConnector) initS3(repoPath, bucketName string) error {
+	return ki.snap.ConnectOrCreateS3(bucketName, repoPath)
+}
+
+// initFilesystem initializes basic mode with a filesystem repository.
+func (ki *kopiaConnector) initFilesystem(repoPath string) error {
+	return ki.snap.ConnectOrCreateFilesystem(repoPath)
+}
+
+// initS3WithServerFn initializes server mode with an S3 repository.
+func (ki *kopiaConnector) initS3WithServer(repoPath, bucketName, addr string) error {
+	cmd, err := ki.snap.ConnectOrCreateS3WithServer(addr, bucketName, repoPath)
+	ki.serverCmd = cmd
+
+	return err
+}
+
+// initFilesystemWithServer initializes server mode with a filesystem repository.
+func (ki *kopiaConnector) initFilesystemWithServer(repoPath, addr string) error {
+	cmd, err := ki.snap.ConnectOrCreateFilesystemWithServer(addr, repoPath)
+	ki.serverCmd = cmd
+
+	return err
+}

--- a/tests/robustness/snapmeta/kopia_connector_test.go
+++ b/tests/robustness/snapmeta/kopia_connector_test.go
@@ -1,0 +1,117 @@
+package snapmeta
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKopiaConnector(t *testing.T) {
+	assert := assert.New(t) // nolint:gocritic
+
+	os.Setenv("KOPIA_EXE", "kopia.exe")
+
+	tc := &testConnector{}
+
+	err := tc.initializeConnector("")
+	assert.NoError(err)
+	assert.NotNil(tc.snap)
+	assert.NotNil(tc.initS3Fn)
+	assert.NotNil(tc.initS3WithServerFn)
+	assert.NotNil(tc.initFilesystemFn)
+	assert.NotNil(tc.initFilesystemWithServerFn)
+
+	tc.initS3Fn = tc.testInitS3
+	tc.initFilesystemFn = tc.testInitFilesystem
+	tc.initS3WithServerFn = tc.testInitS3WithServer
+	tc.initFilesystemWithServerFn = tc.testInitFilesystemWithServer
+
+	repoPath := "repoPath"
+	bucketName := "bucketName"
+
+	os.Setenv(EngineModeEnvKey, EngineModeBasic)
+	os.Setenv(S3BucketNameEnvKey, "")
+	tc.reset()
+	assert.NoError(tc.connectOrCreateRepo(repoPath))
+	assert.True(tc.initFilesystemCalled)
+	assert.Equal(repoPath, tc.tcRepoPath)
+
+	os.Setenv(EngineModeEnvKey, EngineModeBasic)
+	os.Setenv(S3BucketNameEnvKey, bucketName)
+	tc.reset()
+	assert.NoError(tc.connectOrCreateRepo(repoPath))
+	assert.True(tc.initS3Called)
+	assert.Equal(repoPath, tc.tcRepoPath)
+	assert.Equal(bucketName, tc.tcBucketName)
+
+	os.Setenv(EngineModeEnvKey, EngineModeServer)
+	os.Setenv(S3BucketNameEnvKey, "")
+	tc.reset()
+	assert.NoError(tc.connectOrCreateRepo(repoPath))
+	assert.True(tc.initFilesystemWithServerCalled)
+	assert.Equal(repoPath, tc.tcRepoPath)
+	assert.Equal(defaultAddr, tc.tcAddr)
+
+	os.Setenv(EngineModeEnvKey, EngineModeServer)
+	os.Setenv(S3BucketNameEnvKey, bucketName)
+	tc.reset()
+	assert.NoError(tc.connectOrCreateRepo(repoPath))
+	assert.True(tc.initS3WithServerCalled)
+	assert.Equal(repoPath, tc.tcRepoPath)
+	assert.Equal(bucketName, tc.tcBucketName)
+	assert.Equal(defaultAddr, tc.tcAddr)
+}
+
+type testConnector struct {
+	kopiaConnector
+	tcRepoPath                     string
+	tcBucketName                   string
+	tcAddr                         string
+	initS3Called                   bool
+	initFilesystemCalled           bool
+	initS3WithServerCalled         bool
+	initFilesystemWithServerCalled bool
+}
+
+func (tc *testConnector) reset() {
+	tc.tcRepoPath = ""
+	tc.tcBucketName = ""
+	tc.tcAddr = ""
+	tc.initS3Called = false
+	tc.initFilesystemCalled = false
+	tc.initS3WithServerCalled = false
+	tc.initFilesystemWithServerCalled = false
+}
+
+func (tc *testConnector) testInitS3(repoPath, bucketName string) error {
+	tc.tcRepoPath = repoPath
+	tc.tcBucketName = bucketName
+	tc.initS3Called = true
+
+	return nil
+}
+
+func (tc *testConnector) testInitFilesystem(repoPath string) error {
+	tc.tcRepoPath = repoPath
+	tc.initFilesystemCalled = true
+
+	return nil
+}
+
+func (tc *testConnector) testInitS3WithServer(repoPath, bucketName, addr string) error {
+	tc.tcRepoPath = repoPath
+	tc.tcBucketName = bucketName
+	tc.tcAddr = addr
+	tc.initS3WithServerCalled = true
+
+	return nil
+}
+
+func (tc *testConnector) testInitFilesystemWithServer(repoPath, addr string) error {
+	tc.tcRepoPath = repoPath
+	tc.tcAddr = addr
+	tc.initFilesystemWithServerCalled = true
+
+	return nil
+}

--- a/tests/robustness/snapmeta/kopia_snapshotter.go
+++ b/tests/robustness/snapmeta/kopia_snapshotter.go
@@ -43,22 +43,22 @@ func (ks *KopiaSnapshotter) ServerCmd() *exec.Cmd {
 }
 
 // CreateSnapshot is part of Snapshotter.
-func (ks *KopiaSnapshotter) CreateSnapshot(sourceDir string) (snapID string, err error) {
+func (ks *KopiaSnapshotter) CreateSnapshot(sourceDir string, opts map[string]string) (snapID string, err error) {
 	return ks.snap.CreateSnapshot(sourceDir)
 }
 
 // RestoreSnapshot is part of Snapshotter.
-func (ks *KopiaSnapshotter) RestoreSnapshot(snapID, restoreDir string) error {
+func (ks *KopiaSnapshotter) RestoreSnapshot(snapID, restoreDir string, opts map[string]string) error {
 	return ks.snap.RestoreSnapshot(snapID, restoreDir)
 }
 
 // DeleteSnapshot is part of Snapshotter.
-func (ks *KopiaSnapshotter) DeleteSnapshot(snapID string) error {
+func (ks *KopiaSnapshotter) DeleteSnapshot(snapID string, opts map[string]string) error {
 	return ks.snap.DeleteSnapshot(snapID)
 }
 
 // RunGC is part of Snapshotter.
-func (ks *KopiaSnapshotter) RunGC() error {
+func (ks *KopiaSnapshotter) RunGC(opts map[string]string) error {
 	return ks.snap.RunGC()
 }
 

--- a/tests/robustness/snapmeta/kopia_snapshotter.go
+++ b/tests/robustness/snapmeta/kopia_snapshotter.go
@@ -1,0 +1,98 @@
+package snapmeta
+
+import (
+	"os/exec"
+	"strconv"
+
+	"github.com/kopia/kopia/tests/robustness"
+)
+
+// KopiaSnapshotter implements robustness.Snapshotter.
+type KopiaSnapshotter struct {
+	kopiaConnector
+}
+
+var _ robustness.Snapshotter = (*KopiaSnapshotter)(nil)
+
+// NewSnapshotter returns a Kopia based Snapshotter.
+// ConnectOrCreateRepo must be invoked to enable the interface.
+func NewSnapshotter(baseDirPath string) (*KopiaSnapshotter, error) {
+	ks := &KopiaSnapshotter{}
+
+	if err := ks.initializeConnector(baseDirPath); err != nil {
+		return nil, err
+	}
+
+	return ks, nil
+}
+
+// ConnectOrCreateRepo makes the Snapshotter ready for use.
+func (ks *KopiaSnapshotter) ConnectOrCreateRepo(repoPath string) error {
+	if err := ks.connectOrCreateRepo(repoPath); err != nil {
+		return err
+	}
+
+	_, _, err := ks.snap.Run("policy", "set", "--global", "--keep-latest", strconv.Itoa(1<<31-1), "--compression", "s2-default")
+
+	return err
+}
+
+// ServerCmd returns the server command.
+func (ks *KopiaSnapshotter) ServerCmd() *exec.Cmd {
+	return ks.serverCmd
+}
+
+// CreateSnapshot is part of Snapshotter.
+func (ks *KopiaSnapshotter) CreateSnapshot(sourceDir string) (snapID string, err error) {
+	return ks.snap.CreateSnapshot(sourceDir)
+}
+
+// RestoreSnapshot is part of Snapshotter.
+func (ks *KopiaSnapshotter) RestoreSnapshot(snapID, restoreDir string) error {
+	return ks.snap.RestoreSnapshot(snapID, restoreDir)
+}
+
+// DeleteSnapshot is part of Snapshotter.
+func (ks *KopiaSnapshotter) DeleteSnapshot(snapID string) error {
+	return ks.snap.DeleteSnapshot(snapID)
+}
+
+// RunGC is part of Snapshotter.
+func (ks *KopiaSnapshotter) RunGC() error {
+	return ks.snap.RunGC()
+}
+
+// ListSnapshots is part of Snapshotter.
+func (ks *KopiaSnapshotter) ListSnapshots() ([]string, error) {
+	return ks.snap.ListSnapshots()
+}
+
+// Run is part of Snapshotter.
+func (ks *KopiaSnapshotter) Run(args ...string) (stdout, stderr string, err error) {
+	return ks.snap.Run(args...)
+}
+
+// ConnectOrCreateS3 TBD: remove this.
+func (ks *KopiaSnapshotter) ConnectOrCreateS3(bucketName, pathPrefix string) error {
+	return nil
+}
+
+// ConnectOrCreateFilesystem TBD: remove this.
+func (ks *KopiaSnapshotter) ConnectOrCreateFilesystem(path string) error {
+	return nil
+}
+
+// ConnectOrCreateS3WithServer TBD: remove this.
+func (ks *KopiaSnapshotter) ConnectOrCreateS3WithServer(serverAddr, bucketName, pathPrefix string) (*exec.Cmd, error) {
+	return nil, nil
+}
+
+// ConnectOrCreateFilesystemWithServer TBD: remove this.
+func (ks *KopiaSnapshotter) ConnectOrCreateFilesystemWithServer(serverAddr, repoPath string) (*exec.Cmd, error) {
+	return nil, nil
+}
+
+// Cleanup should be called before termination.
+func (ks *KopiaSnapshotter) Cleanup() {
+	ks.snap.Cleanup()
+}

--- a/tests/robustness/snapshotter.go
+++ b/tests/robustness/snapshotter.go
@@ -3,27 +3,13 @@
 // can be used to test other environments.
 package robustness
 
-import "os/exec"
-
 // Snapshotter is an interface that describes methods
 // for taking, restoring, deleting snapshots, and
 // tracking them by a string snapshot ID.
 type Snapshotter interface {
-	RepoManager // TBD: may not be needed once initialization refactored
 	CreateSnapshot(sourceDir string) (snapID string, err error)
 	RestoreSnapshot(snapID string, restoreDir string) error
 	DeleteSnapshot(snapID string) error
 	RunGC() error
 	ListSnapshots() ([]string, error)
-	Run(args ...string) (stdout, stderr string, err error) // TBD: remove once initialization refactored
-}
-
-// RepoManager is an interface that describes connecting to
-// a repository.
-// TBD: may not be needed once initialization refactored.
-type RepoManager interface {
-	ConnectOrCreateS3(bucketName, pathPrefix string) error
-	ConnectOrCreateFilesystem(path string) error
-	ConnectOrCreateS3WithServer(serverAddr, bucketName, pathPrefix string) (*exec.Cmd, error)
-	ConnectOrCreateFilesystemWithServer(serverAddr, repoPath string) (*exec.Cmd, error)
 }

--- a/tests/robustness/snapshotter.go
+++ b/tests/robustness/snapshotter.go
@@ -7,9 +7,9 @@ package robustness
 // for taking, restoring, deleting snapshots, and
 // tracking them by a string snapshot ID.
 type Snapshotter interface {
-	CreateSnapshot(sourceDir string) (snapID string, err error)
-	RestoreSnapshot(snapID string, restoreDir string) error
-	DeleteSnapshot(snapID string) error
-	RunGC() error
+	CreateSnapshot(sourceDir string, opts map[string]string) (snapID string, err error)
+	RestoreSnapshot(snapID string, restoreDir string, opts map[string]string) error
+	DeleteSnapshot(snapID string, opts map[string]string) error
+	RunGC(opts map[string]string) error
 	ListSnapshots() ([]string, error)
 }

--- a/tests/tools/fswalker/fswalker.go
+++ b/tests/tools/fswalker/fswalker.go
@@ -46,7 +46,7 @@ func NewWalkCompare() *WalkCompare {
 
 // Gather meets the checker.Comparer interface. It performs a fswalker Walk
 // and returns the resulting Walk as a protobuf Marshaled buffer.
-func (chk *WalkCompare) Gather(ctx context.Context, path string) ([]byte, error) {
+func (chk *WalkCompare) Gather(ctx context.Context, path string, opts map[string]string) ([]byte, error) {
 	walkData, err := performWalk(ctx, path)
 	if err != nil {
 		return nil, errors.Wrap(err, "walk with hashing error during gather phase")
@@ -91,7 +91,7 @@ func clearHostname(walk *fspb.Walk) {
 // and generates a fswalker report comparing the two Walks. If there are any differences
 // an error is returned, and the full report will be written to the provided writer
 // as JSON.
-func (chk *WalkCompare) Compare(ctx context.Context, path string, data []byte, reportOut io.Writer) error {
+func (chk *WalkCompare) Compare(ctx context.Context, path string, data []byte, reportOut io.Writer, opts map[string]string) error {
 	beforeWalk := &fspb.Walk{}
 
 	err := proto.Unmarshal(data, beforeWalk)

--- a/tests/tools/fswalker/fswalker_test.go
+++ b/tests/tools/fswalker/fswalker_test.go
@@ -213,7 +213,7 @@ func TestWalkChecker_GatherCompare(t *testing.T) {
 
 		ctx := context.TODO()
 
-		walk, err := chk.Gather(ctx, tmpDir)
+		walk, err := chk.Gather(ctx, tmpDir, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -221,7 +221,7 @@ func TestWalkChecker_GatherCompare(t *testing.T) {
 		tt.fileTreeModifier(tmpDir)
 
 		reportOut := &bytes.Buffer{}
-		if err := chk.Compare(ctx, tmpDir, walk, reportOut); (err != nil) != tt.wantErr {
+		if err := chk.Compare(ctx, tmpDir, walk, reportOut, nil); (err != nil) != tt.wantErr {
 			t.Errorf("Compare error = %v, wantErr %v", err, tt.wantErr)
 			return
 		}

--- a/tests/tools/kopiarunner/kopia_snapshotter.go
+++ b/tests/tools/kopiarunner/kopia_snapshotter.go
@@ -19,10 +19,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/kopia/kopia/internal/retry"
-	"github.com/kopia/kopia/tests/robustness"
 )
-
-var _ robustness.Snapshotter = &KopiaSnapshotter{}
 
 const (
 	contentCacheSizeMBFlag  = "--content-cache-size-mb"


### PR DESCRIPTION
Using the `snapmeta` directory as the implementation of both the Kopia `Persister` and the Kopia `Snapshotter`.

Ran the engine tests and the TestOneLargeFile robustness test.