### PR TITLE
Fixes for current Robustness Server Job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -241,7 +241,7 @@ endurance-tests: build-integration-test-binary $(gotestsum)
 robustness-tests: export KOPIA_EXE ?= $(KOPIA_INTEGRATION_EXE)
 robustness-tests: build-integration-test-binary $(gotestsum)
 	FIO_DOCKER_IMAGE=$(FIO_DOCKER_TAG) \
-	$(GO_TEST) -count=1 github.com/kopia/kopia/tests/robustness/robustness_test $(TEST_FLAGS)
+	$(GO_TEST) -race -count=1 github.com/kopia/kopia/tests/robustness/robustness_test $(TEST_FLAGS)
 
 robustness-tool-tests: export KOPIA_EXE ?= $(KOPIA_INTEGRATION_EXE)
 robustness-tool-tests: build-integration-test-binary $(gotestsum)

--- a/repo/blob/s3/s3_storage.go
+++ b/repo/blob/s3/s3_storage.go
@@ -99,6 +99,11 @@ func isRetriableError(err error) bool {
 		return true
 	}
 
+	if strings.Contains(strings.ToLower(err.Error()), "tcp") {
+		// retry tcp transport errors, such as "connection reset"
+		return true
+	}
+
 	return false
 }
 

--- a/tests/robustness/engine/engine_test.go
+++ b/tests/robustness/engine/engine_test.go
@@ -51,7 +51,7 @@ func TestEngineWritefilesBasicFS(t *testing.T) {
 	testenv.AssertNoError(t, err)
 
 	defer func() {
-		cleanupErr := eng.Cleanup(0)
+		cleanupErr := eng.Cleanup()
 		testenv.AssertNoError(t, cleanupErr)
 
 		os.RemoveAll(fsRepoBaseDirPath)
@@ -163,7 +163,7 @@ func TestWriteFilesBasicS3(t *testing.T) {
 	testenv.AssertNoError(t, err)
 
 	defer func() {
-		cleanupErr := eng.Cleanup(0)
+		cleanupErr := eng.Cleanup()
 		testenv.AssertNoError(t, cleanupErr)
 	}()
 
@@ -205,7 +205,7 @@ func TestDeleteSnapshotS3(t *testing.T) {
 	testenv.AssertNoError(t, err)
 
 	defer func() {
-		cleanupErr := eng.Cleanup(0)
+		cleanupErr := eng.Cleanup()
 		testenv.AssertNoError(t, cleanupErr)
 	}()
 
@@ -248,7 +248,7 @@ func TestSnapshotVerificationFail(t *testing.T) {
 	testenv.AssertNoError(t, err)
 
 	defer func() {
-		cleanupErr := eng.Cleanup(0)
+		cleanupErr := eng.Cleanup()
 		testenv.AssertNoError(t, cleanupErr)
 	}()
 
@@ -313,7 +313,7 @@ func TestDataPersistency(t *testing.T) {
 	testenv.AssertNoError(t, err)
 
 	defer func() {
-		cleanupErr := eng.Cleanup(0)
+		cleanupErr := eng.Cleanup()
 		testenv.AssertNoError(t, cleanupErr)
 	}()
 
@@ -470,7 +470,7 @@ func TestActionsFilesystem(t *testing.T) {
 	testenv.AssertNoError(t, err)
 
 	defer func() {
-		cleanupErr := eng.Cleanup(0)
+		cleanupErr := eng.Cleanup()
 		testenv.AssertNoError(t, cleanupErr)
 
 		os.RemoveAll(fsRepoBaseDirPath)
@@ -515,7 +515,7 @@ func TestActionsS3(t *testing.T) {
 	testenv.AssertNoError(t, err)
 
 	defer func() {
-		cleanupErr := eng.Cleanup(0)
+		cleanupErr := eng.Cleanup()
 		testenv.AssertNoError(t, cleanupErr)
 	}()
 
@@ -562,7 +562,7 @@ func TestIOLimitPerWriteAction(t *testing.T) {
 	testenv.AssertNoError(t, err)
 
 	defer func() {
-		cleanupErr := eng.Cleanup(0)
+		cleanupErr := eng.Cleanup()
 		testenv.AssertNoError(t, cleanupErr)
 
 		os.RemoveAll(fsRepoBaseDirPath)
@@ -630,17 +630,19 @@ func TestStatsPersist(t *testing.T) {
 
 	eng := &Engine{
 		MetaStore: snapStore,
-		CumulativeStats: Stats{
-			ActionCounter: 11235,
-			CreationTime:  creationTime,
-			PerActionStats: map[ActionKey]*ActionStats{
-				ActionKey("some-action"): actionstats,
+		CumulativeStats: []Stats{
+			{
+				ActionCounter: 11235,
+				CreationTime:  creationTime,
+				PerActionStats: map[ActionKey]*ActionStats{
+					ActionKey("some-action"): actionstats,
+				},
+				DataRestoreCount: 99,
 			},
-			DataRestoreCount: 99,
 		},
 	}
 
-	err = eng.SaveStats()
+	err = eng.SaveStats(0)
 	testenv.AssertNoError(t, err)
 
 	err = eng.MetaStore.FlushMetadata()
@@ -660,15 +662,15 @@ func TestStatsPersist(t *testing.T) {
 		MetaStore: snapStoreNew,
 	}
 
-	err = engNew.LoadStats()
+	err = engNew.LoadStats(0)
 	testenv.AssertNoError(t, err)
 
-	if got, want := engNew.Stats(), eng.Stats(); got != want {
+	if got, want := engNew.Stats(0), eng.Stats(0); got != want {
 		t.Errorf("Stats do not match\n%v\n%v", got, want)
 	}
 
-	fmt.Println(eng.Stats())
-	fmt.Println(engNew.Stats())
+	fmt.Println(eng.Stats(0))
+	fmt.Println(engNew.Stats(0))
 }
 
 func TestLogsPersist(t *testing.T) {
@@ -707,10 +709,12 @@ func TestLogsPersist(t *testing.T) {
 
 	eng := &Engine{
 		MetaStore: snapStore,
-		EngineLog: log,
+		EngineLog: []Log{
+			log,
+		},
 	}
 
-	err = eng.SaveLog()
+	err = eng.SaveLog(0)
 	testenv.AssertNoError(t, err)
 
 	err = eng.MetaStore.FlushMetadata()
@@ -730,10 +734,10 @@ func TestLogsPersist(t *testing.T) {
 		MetaStore: snapStoreNew,
 	}
 
-	err = engNew.LoadLog()
+	err = engNew.LoadLog(0)
 	testenv.AssertNoError(t, err)
 
-	if got, want := engNew.EngineLog.String(), eng.EngineLog.String(); got != want {
+	if got, want := engNew.EngineLog[0].String(), eng.EngineLog[0].String(); got != want {
 		t.Errorf("Logs do not match\n%v\n%v", got, want)
 	}
 }

--- a/tests/robustness/engine/engine_test.go
+++ b/tests/robustness/engine/engine_test.go
@@ -349,7 +349,7 @@ func TestDataPersistency(t *testing.T) {
 	eng2, err := NewEngine("")
 	testenv.AssertNoError(t, err)
 
-	defer eng2.CleanComponents()
+	defer eng2.CleanAllComponents()
 
 	// Connect this engine to the same data and metadata repositories -
 	// expect that the snapshot taken above will be found in metadata,

--- a/tests/robustness/engine/metadata.go
+++ b/tests/robustness/engine/metadata.go
@@ -16,8 +16,8 @@ const (
 )
 
 // SaveLog saves the engine Log in the metadata store.
-func (e *Engine) SaveLog() error {
-	b, err := json.Marshal(e.EngineLog)
+func (e *Engine) SaveLog(index int) error {
+	b, err := json.Marshal(e.EngineLog[index])
 	if err != nil {
 		return err
 	}
@@ -26,7 +26,7 @@ func (e *Engine) SaveLog() error {
 }
 
 // LoadLog loads the engine log from the metadata store.
-func (e *Engine) LoadLog() error {
+func (e *Engine) LoadLog(index int) error {
 	b, err := e.MetaStore.Load(engineLogsStoreKey)
 	if err != nil {
 		if errors.Is(err, snapmeta.ErrKeyNotFound) {
@@ -37,19 +37,19 @@ func (e *Engine) LoadLog() error {
 		return err
 	}
 
-	err = json.Unmarshal(b, &e.EngineLog)
+	err = json.Unmarshal(b, &e.EngineLog[index])
 	if err != nil {
 		return err
 	}
 
-	e.EngineLog.runOffset = len(e.EngineLog.Log)
+	e.EngineLog[index].runOffset = len(e.EngineLog[index].Log)
 
 	return err
 }
 
 // SaveStats saves the engine Stats in the metadata store.
-func (e *Engine) SaveStats() error {
-	cumulStatRaw, err := json.Marshal(e.CumulativeStats)
+func (e *Engine) SaveStats(index int) error {
+	cumulStatRaw, err := json.Marshal(e.CumulativeStats[index])
 	if err != nil {
 		return err
 	}
@@ -58,20 +58,20 @@ func (e *Engine) SaveStats() error {
 }
 
 // LoadStats loads the engine Stats from the metadata store.
-func (e *Engine) LoadStats() error {
+func (e *Engine) LoadStats(index int) error {
 	b, err := e.MetaStore.Load(engineStatsStoreKey)
 	if err != nil {
 		if errors.Is(err, snapmeta.ErrKeyNotFound) {
+			e.CumulativeStats[index] = Stats{}
 			// Swallow key-not-found error. We may not have historical
 			// stats data. Initialize the action map for the cumulative stats
-			e.CumulativeStats.PerActionStats = make(map[ActionKey]*ActionStats)
-			e.CumulativeStats.CreationTime = time.Now()
+			e.CumulativeStats[index].PerActionStats = make(map[ActionKey]*ActionStats)
+			e.CumulativeStats[index].CreationTime = time.Now()
 
 			return nil
 		}
-
 		return err
 	}
 
-	return json.Unmarshal(b, &e.CumulativeStats)
+	return json.Unmarshal(b, &e.CumulativeStats[index])
 }

--- a/tests/robustness/engine/stats.go
+++ b/tests/robustness/engine/stats.go
@@ -18,7 +18,7 @@ var (
 )
 
 // Stats prints the engine stats, cumulative and from the current run.
-func (e *Engine) Stats() string {
+func (e *Engine) Stats(index int) string {
 	b := &strings.Builder{}
 
 	fmt.Fprintln(b, "==================================")
@@ -35,15 +35,16 @@ func (e *Engine) Stats() string {
 	fmt.Fprintln(b, "==================================")
 	fmt.Fprintln(b, "Engine Action Summary (Cumulative)")
 	fmt.Fprintln(b, "==================================")
-	fmt.Fprintf(b, "  Engine runtime:   %10vs\n", e.getRuntimeSeconds())
+	fmt.Fprintf(b, "  Engine runtime:   %10vs\n", e.getRuntimeSeconds(index))
 	fmt.Fprintln(b, "")
-	fmt.Fprint(b, e.CumulativeStats.Stats())
+	fmt.Fprint(b, e.CumulativeStats[index].Stats())
 	fmt.Fprintln(b, "")
 
 	fmt.Fprintln(b, "==================================")
 	fmt.Fprintln(b, "Engine Action Summary (This Run)")
 	fmt.Fprintln(b, "==================================")
-	fmt.Fprint(b, e.RunStats.Stats())
+	fmt.Fprintf(b, "  Engine Index:     %10v\n", index)
+	fmt.Fprint(b, e.RunStats[index].Stats())
 	fmt.Fprintln(b, "")
 
 	return b.String()
@@ -146,10 +147,10 @@ func (s *ActionStats) avgRuntimeString() string {
 	return fmt.Sprintf("%vs", durationToSec(s.AverageRuntime()))
 }
 
-func (e *Engine) getTimestampS() int64 {
-	return e.getRuntimeSeconds()
+func (e *Engine) getTimestampS(index int) int64 {
+	return e.getRuntimeSeconds(index)
 }
 
-func (e *Engine) getRuntimeSeconds() int64 {
-	return durationToSec(e.CumulativeStats.RunTime + time.Since(e.RunStats.CreationTime))
+func (e *Engine) getRuntimeSeconds(index int) int64 {
+	return durationToSec(e.CumulativeStats[index].RunTime + time.Since(e.RunStats[index].CreationTime))
 }

--- a/tests/robustness/robustness_test/main_test.go
+++ b/tests/robustness/robustness_test/main_test.go
@@ -63,7 +63,7 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		// Clean the temporary dirs from the file system, don't write out the
 		// metadata, in case there was an issue loading it
-		eng.CleanComponents()
+		eng.CleanAllComponents()
 		log.Fatalln("error initializing engine for S3:", err)
 	}
 	// Restore a random snapshot into the data directory

--- a/tests/robustness/robustness_test/robustness_test.go
+++ b/tests/robustness/robustness_test/robustness_test.go
@@ -122,6 +122,9 @@ func TestManySmallFilesAcrossDirecoryTree(t *testing.T) {
 			})
 		}(i)
 	}
+
+	err := errs.Wait()
+	testenv.AssertNoError(t, err)
 }
 
 func TestRandomizedSmall(t *testing.T) {
@@ -154,11 +157,13 @@ func TestRandomizedSmall(t *testing.T) {
 						t.Log("Random action resulted in no-op")
 						err = nil
 					}
-
-					testenv.AssertNoError(t, err)
+					return err
 				}
 				return nil
 			})
 		}(i)
 	}
+
+	err := errs.Wait()
+	testenv.AssertNoError(t, err)
 }


### PR DESCRIPTION
 Changelog:
    - Used individual Stats for each Kopia Client
    - Added engineIndex logs for a lot of existing logs, as due to concurrent operations, logs are tough to debug
    - Simplified CleanUp Procedure (with just one function being executed outside go routines)