### PR TITLE
add error handling for robustness Checker

### DIFF
--- a/tests/robustness/checker/checker.go
+++ b/tests/robustness/checker/checker.go
@@ -206,6 +206,9 @@ func (chk *Checker) VerifySnapshotMetadata(ctx context.Context) error {
 // performs the snapshot action defined by the Checker's Snapshotter.
 func (chk *Checker) TakeSnapshot(ctx context.Context, sourceDir string, opts map[string]string) (snapID string, err error) {
 	snapID, fingerprint, stats, err := chk.snapshotIssuer.CreateSnapshot(ctx, sourceDir, opts)
+	if err != nil {
+		return snapID, err
+	}
 
 	ssMeta := &SnapshotMetadata{
 		SnapID:         snapID,


### PR DESCRIPTION
This seemed to be missing error handling right after calling `CreateSnapshot`. This can cause a panic on line 215 if `CreateSnapshot` returns before setting the `stats` struct, which it has two opportunities to do.