### PR TITLE
add Cleanup method to FileWriter and Snapshotter

### DIFF
--- a/tests/robustness/filewriter.go
+++ b/tests/robustness/filewriter.go
@@ -26,4 +26,7 @@ type FileWriter interface {
 	// on its input option values (none of which are required).
 	// The method returns the effective option values used and the error if any.
 	WriteRandomFiles(ctx context.Context, opts map[string]string) (map[string]string, error)
+
+	// Cleanup cleans up the FileWriter.
+	Cleanup()
 }

--- a/tests/robustness/snapshotter.go
+++ b/tests/robustness/snapshotter.go
@@ -19,6 +19,7 @@ type Snapshotter interface {
 	DeleteSnapshot(ctx context.Context, snapID string, opts map[string]string) error
 	RunGC(ctx context.Context, opts map[string]string) error
 	ListSnapshots(ctx context.Context) ([]string, error)
+	Cleanup()
 }
 
 // CreateSnapshotStats is a struct for returning various stats from the snapshot execution.


### PR DESCRIPTION
Add a `Cleanup` method to the `FileWriter` and `Snapshotter` interfaces used in robustness testing.

This method is present in existing implementations already and is needed for the `MultiClientFileWriter` and `MultiClientSnapshotter` abstractions. On cleanup, the multiclient `FileWriter` / `Snapshotter` will call the `Cleanup` method for each client `FileWriter` / `Snapshotter`.