### PR TITLE
create client package for robustness tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/aws/aws-sdk-go v1.38.18
 	github.com/chmduquesne/rollinghash v4.0.0+incompatible
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/dustinkirkland/golang-petname v0.0.0-20191129215211-8e5a1ed0cff0 // indirect
 	github.com/efarrer/iothrottler v0.0.1
 	github.com/fatih/color v1.10.0
 	github.com/foomo/htpasswd v0.0.0-20200116085101-e3a90e78da9c

--- a/go.sum
+++ b/go.sum
@@ -209,6 +209,8 @@ github.com/dswarbrick/smart v0.0.0-20190505152634-909a45200d6d/go.mod h1:apXo4PA
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/dustinkirkland/golang-petname v0.0.0-20191129215211-8e5a1ed0cff0 h1:90Ly+6UfUypEF6vvvW5rQIv9opIL8CbmW9FT20LDQoY=
+github.com/dustinkirkland/golang-petname v0.0.0-20191129215211-8e5a1ed0cff0/go.mod h1:V+Qd57rJe8gd4eiGzZyg4h54VLHmYVVw54iMnlAMrF8=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-resiliency v1.2.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=

--- a/tests/robustness/multiclient/client/client.go
+++ b/tests/robustness/multiclient/client/client.go
@@ -23,24 +23,26 @@ type Client struct {
 	ID string
 }
 
-func newClient() *Client {
+func init() {
 	petname.NonDeterministicMode()
+}
 
+func newClient() *Client {
 	return &Client{
 		ID: petname.Generate(nameLen, "-") + "-" + uuid.NewString(),
 	}
 }
 
-// WrapContext returns a copy of ctx with a new client.
-func WrapContext(ctx context.Context) context.Context {
+// NewClientContext returns a copy of ctx with a new client.
+func NewClientContext(ctx context.Context) context.Context {
 	return context.WithValue(ctx, clientKey, newClient())
 }
 
-// WrapContexts returns copies of ctx with n new clients.
-func WrapContexts(ctx context.Context, n int) []context.Context {
+// NewClientContexts returns copies of ctx with n new clients.
+func NewClientContexts(ctx context.Context, n int) []context.Context {
 	ctxs := make([]context.Context, n)
 	for i := range ctxs {
-		ctxs[i] = WrapContext(ctx)
+		ctxs[i] = NewClientContext(ctx)
 	}
 
 	return ctxs

--- a/tests/robustness/multiclient/client/client.go
+++ b/tests/robustness/multiclient/client/client.go
@@ -11,12 +11,9 @@ import (
 	"github.com/google/uuid"
 )
 
-type key int
+const nameLen int = 2
 
-const (
-	clientKey key = 0
-	nameLen   int = 2
-)
+var clientKey = struct{}{}
 
 // Client is a unique client for use in multiclient robustness tests.
 type Client struct {
@@ -49,9 +46,9 @@ func NewClientContexts(ctx context.Context, n int) []context.Context {
 }
 
 // UnwrapContext returns a client from the given context.
-func UnwrapContext(ctx context.Context) (*Client, bool) {
-	c, ok := ctx.Value(clientKey).(*Client)
-	return c, ok
+func UnwrapContext(ctx context.Context) *Client {
+	c, _ := ctx.Value(clientKey).(*Client)
+	return c
 }
 
 // RunAllAndWait runs the provided function asynchronously for each of the

--- a/tests/robustness/multiclient/client/client.go
+++ b/tests/robustness/multiclient/client/client.go
@@ -1,0 +1,70 @@
+// +build darwin,amd64 linux,amd64
+
+// Package client manages client specific info
+package client
+
+import (
+	"context"
+	"sync"
+
+	petname "github.com/dustinkirkland/golang-petname"
+	"github.com/google/uuid"
+)
+
+type key int
+
+const (
+	clientKey key = 0
+	nameLen   int = 2
+)
+
+// Client is a unique client for use in multiclient robustness tests.
+type Client struct {
+	ID string
+}
+
+func newClient() *Client {
+	petname.NonDeterministicMode()
+
+	return &Client{
+		ID: petname.Generate(nameLen, "-") + "-" + uuid.NewString(),
+	}
+}
+
+// WrapContext returns a copy of ctx with a new client.
+func WrapContext(ctx context.Context) context.Context {
+	return context.WithValue(ctx, clientKey, newClient())
+}
+
+// WrapContexts returns copies of ctx with n new clients.
+func WrapContexts(ctx context.Context, n int) []context.Context {
+	ctxs := make([]context.Context, n)
+	for i := range ctxs {
+		ctxs[i] = WrapContext(ctx)
+	}
+
+	return ctxs
+}
+
+// UnwrapContext returns a client from the given context.
+func UnwrapContext(ctx context.Context) (*Client, bool) {
+	c, ok := ctx.Value(clientKey).(*Client)
+	return c, ok
+}
+
+// RunAllAndWait runs the provided function asynchronously for each of the
+// given client contexts and waits for all of them to finish.
+func RunAllAndWait(ctxs []context.Context, f func(context.Context)) {
+	var wg sync.WaitGroup
+
+	for _, ctx := range ctxs {
+		wg.Add(1)
+
+		go func(ctx context.Context) {
+			f(ctx)
+			wg.Done()
+		}(ctx)
+	}
+
+	wg.Wait()
+}

--- a/tests/robustness/multiclient_test/framework/client.go
+++ b/tests/robustness/multiclient_test/framework/client.go
@@ -1,7 +1,6 @@
 // +build darwin,amd64 linux,amd64
 
-// Package client manages client specific info
-package client
+package framework
 
 import (
 	"context"

--- a/tests/robustness/multiclient_test/framework/client.go
+++ b/tests/robustness/multiclient_test/framework/client.go
@@ -1,5 +1,7 @@
 // +build darwin,amd64 linux,amd64
 
+// Package framework contains tools to enable multiple clients to connect to a
+// central repository server and run robustness tests concurrently.
 package framework
 
 import (


### PR DESCRIPTION
The client package is used in multi-client robustness tests. Clients are lightweight (just a unique identifier) and are wrapped in a context that can be passed across interface boundaries. The multi-client `Snapshotter` and `FileWriter` will unwrap the client from the context and delegate actions based on the client ID.

This package also contains a utility `RunAllAndWait` for running tests with multiple clients concurrently.