### PR TITLE
robustness engine updates for concurrency

### DIFF
--- a/tests/robustness/engine/action.go
+++ b/tests/robustness/engine/action.go
@@ -22,9 +22,16 @@ func (e *Engine) ExecAction(ctx context.Context, actionKey ActionKey, opts map[s
 		opts = make(map[string]string)
 	}
 
-	e.RunStats.ActionCounter++
-	e.CumulativeStats.ActionCounter++
-	log.Printf("Engine executing ACTION: name=%q actionCount=%v totActCount=%v t=%vs (%vs)", actionKey, e.RunStats.ActionCounter, e.CumulativeStats.ActionCounter, e.RunStats.getLifetimeSeconds(), e.getRuntimeSeconds())
+	e.RunStats.IncrementActionCount()
+	e.CumulativeStats.IncrementActionCount()
+	log.Printf(
+		"Engine executing ACTION: name=%q actionCount=%v totActCount=%v t=%vs (%vs)",
+		actionKey,
+		e.RunStats.GetActionCount(),
+		e.CumulativeStats.GetActionCount(),
+		e.RunStats.getLifetimeSeconds(),
+		e.getRuntimeSeconds(),
+	)
 
 	action := actions[actionKey]
 	st := clock.Now()
@@ -53,8 +60,8 @@ func (e *Engine) ExecAction(ctx context.Context, actionKey ActionKey, opts map[s
 	// If error was just a no-op, don't bother logging the action
 	switch {
 	case errors.Is(err, robustness.ErrNoOp):
-		e.RunStats.NoOpCount++
-		e.CumulativeStats.NoOpCount++
+		e.RunStats.IncrementNoOpCount()
+		e.CumulativeStats.IncrementNoOpCount()
 
 		return out, err
 
@@ -62,16 +69,8 @@ func (e *Engine) ExecAction(ctx context.Context, actionKey ActionKey, opts map[s
 		log.Printf("error=%q", err.Error())
 	}
 
-	if e.RunStats.PerActionStats != nil && e.RunStats.PerActionStats[actionKey] == nil {
-		e.RunStats.PerActionStats[actionKey] = new(ActionStats)
-	}
-
-	if e.CumulativeStats.PerActionStats != nil && e.CumulativeStats.PerActionStats[actionKey] == nil {
-		e.CumulativeStats.PerActionStats[actionKey] = new(ActionStats)
-	}
-
-	e.RunStats.PerActionStats[actionKey].Record(st, err)
-	e.CumulativeStats.PerActionStats[actionKey].Record(st, err)
+	e.RunStats.RecordAction(actionKey, st, err)
+	e.CumulativeStats.RecordAction(actionKey, st, err)
 
 	e.EngineLog.AddCompleted(logEntry, err)
 
@@ -112,8 +111,8 @@ func (e *Engine) checkErrRecovery(ctx context.Context, incomingErr error, action
 			return outgoingErr
 		}
 
-		e.RunStats.DataPurgeCount++
-		e.CumulativeStats.DataPurgeCount++
+		e.RunStats.IncrementDataPurgeCount()
+		e.CumulativeStats.IncrementDataPurgeCount()
 
 		// Restore a previoius snapshot to the data directory
 		restoreActionKey := RestoreIntoDataDirectoryActionKey
@@ -122,14 +121,14 @@ func (e *Engine) checkErrRecovery(ctx context.Context, incomingErr error, action
 		if errors.Is(outgoingErr, robustness.ErrNoOp) {
 			outgoingErr = nil
 		} else {
-			e.RunStats.DataRestoreCount++
-			e.CumulativeStats.DataRestoreCount++
+			e.RunStats.IncrementDataRestoreCount()
+			e.CumulativeStats.IncrementDataRestoreCount()
 		}
 	}
 
 	if outgoingErr == nil {
-		e.RunStats.ErrorRecoveryCount++
-		e.CumulativeStats.ErrorRecoveryCount++
+		e.RunStats.IncrementErrorRecoveryCount()
+		e.CumulativeStats.IncrementErrorRecoveryCount()
 	}
 
 	return outgoingErr

--- a/tests/robustness/engine/action.go
+++ b/tests/robustness/engine/action.go
@@ -51,7 +51,7 @@ func (e *Engine) ExecAction(ctx context.Context, actionKey ActionKey, opts map[s
 	// If error was just a no-op, don't bother logging the action
 	switch {
 	case errors.Is(err, robustness.ErrNoOp):
-		e.statsUpdateCounters(incrNoOp)
+		e.statsUpdateCounters(statsIncrNoOp)
 
 		return out, err
 
@@ -63,13 +63,6 @@ func (e *Engine) ExecAction(ctx context.Context, actionKey ActionKey, opts map[s
 	e.logCompleted(logEntry, err)
 
 	return out, err
-}
-
-func (e *Engine) logCompleted(logEntry *LogEntry, err error) {
-	e.logMux.Lock()
-	defer e.logMux.Unlock()
-
-	e.EngineLog.AddCompleted(logEntry, err)
 }
 
 // RandomAction executes a random action picked by the relative weights given
@@ -106,7 +99,7 @@ func (e *Engine) checkErrRecovery(ctx context.Context, incomingErr error, action
 			return outgoingErr
 		}
 
-		e.statsUpdateCounters(incrDataPurge)
+		e.statsUpdateCounters(statsIncrDataPurge)
 
 		// Restore a previoius snapshot to the data directory
 		restoreActionKey := RestoreIntoDataDirectoryActionKey
@@ -115,12 +108,12 @@ func (e *Engine) checkErrRecovery(ctx context.Context, incomingErr error, action
 		if errors.Is(outgoingErr, robustness.ErrNoOp) {
 			outgoingErr = nil
 		} else {
-			e.statsUpdateCounters(incrDataRestore)
+			e.statsUpdateCounters(statsIncrDataRestore)
 		}
 	}
 
 	if outgoingErr == nil {
-		e.statsUpdateCounters(incrErrorRecovery)
+		e.statsUpdateCounters(statsIncrErrorRecovery)
 	}
 
 	return outgoingErr

--- a/tests/robustness/engine/engine.go
+++ b/tests/robustness/engine/engine.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/tests/robustness"
@@ -97,7 +98,10 @@ type Engine struct {
 
 	RunStats        Stats
 	CumulativeStats Stats
-	EngineLog       Log
+	statsMux        sync.RWMutex
+
+	EngineLog Log
+	logMux    sync.RWMutex
 }
 
 // Shutdown makes a last snapshot then flushes the metadata and prints the final statistics.

--- a/tests/robustness/engine/engine.go
+++ b/tests/robustness/engine/engine.go
@@ -59,7 +59,7 @@ func New(args *Args) (*Engine, error) {
 			TestRepo:    args.TestRepo,
 			FileWriter:  args.FileWriter,
 			baseDirPath: args.WorkingDir,
-			RunStats: Stats{
+			RunStats: &Stats{
 				RunCounter:     1,
 				CreationTime:   clock.Now(),
 				PerActionStats: make(map[ActionKey]*ActionStats),
@@ -95,9 +95,9 @@ type Engine struct {
 	cleanupRoutines []func()
 	baseDirPath     string
 
-	RunStats        Stats
-	CumulativeStats Stats
-	EngineLog       Log
+	RunStats        *Stats
+	CumulativeStats *Stats
+	EngineLog       *Log
 }
 
 // Shutdown makes a last snapshot then flushes the metadata and prints the final statistics.

--- a/tests/robustness/engine/engine.go
+++ b/tests/robustness/engine/engine.go
@@ -59,7 +59,7 @@ func New(args *Args) (*Engine, error) {
 			TestRepo:    args.TestRepo,
 			FileWriter:  args.FileWriter,
 			baseDirPath: args.WorkingDir,
-			RunStats: &Stats{
+			RunStats: Stats{
 				RunCounter:     1,
 				CreationTime:   clock.Now(),
 				PerActionStats: make(map[ActionKey]*ActionStats),
@@ -95,9 +95,9 @@ type Engine struct {
 	cleanupRoutines []func()
 	baseDirPath     string
 
-	RunStats        *Stats
-	CumulativeStats *Stats
-	EngineLog       *Log
+	RunStats        Stats
+	CumulativeStats Stats
+	EngineLog       Log
 }
 
 // Shutdown makes a last snapshot then flushes the metadata and prints the final statistics.

--- a/tests/robustness/engine/engine_test.go
+++ b/tests/robustness/engine/engine_test.go
@@ -719,7 +719,7 @@ func TestStatsPersist(t *testing.T) {
 
 	eng := &Engine{
 		MetaStore: snapStore,
-		CumulativeStats: &Stats{
+		CumulativeStats: Stats{
 			ActionCounter: 11235,
 			CreationTime:  creationTime,
 			PerActionStats: map[ActionKey]*ActionStats{
@@ -776,7 +776,7 @@ func TestLogsPersist(t *testing.T) {
 	err = snapStore.ConnectOrCreateFilesystem(tmpDir)
 	testenv.AssertNoError(t, err)
 
-	logData := &Log{
+	logData := Log{
 		Log: []*LogEntry{
 			{
 				StartTime: clock.Now().Add(-time.Hour),

--- a/tests/robustness/engine/engine_test.go
+++ b/tests/robustness/engine/engine_test.go
@@ -719,7 +719,7 @@ func TestStatsPersist(t *testing.T) {
 
 	eng := &Engine{
 		MetaStore: snapStore,
-		CumulativeStats: Stats{
+		CumulativeStats: &Stats{
 			ActionCounter: 11235,
 			CreationTime:  creationTime,
 			PerActionStats: map[ActionKey]*ActionStats{
@@ -776,7 +776,7 @@ func TestLogsPersist(t *testing.T) {
 	err = snapStore.ConnectOrCreateFilesystem(tmpDir)
 	testenv.AssertNoError(t, err)
 
-	logData := Log{
+	logData := &Log{
 		Log: []*LogEntry{
 			{
 				StartTime: clock.Now().Add(-time.Hour),

--- a/tests/robustness/engine/log.go
+++ b/tests/robustness/engine/log.go
@@ -126,3 +126,10 @@ func setLogEntryCmdOpts(l *LogEntry, opts map[string]string) {
 
 	l.CmdOpts = opts
 }
+
+func (e *Engine) logCompleted(logEntry *LogEntry, err error) {
+	e.logMux.Lock()
+	defer e.logMux.Unlock()
+
+	e.EngineLog.AddCompleted(logEntry, err)
+}

--- a/tests/robustness/engine/log.go
+++ b/tests/robustness/engine/log.go
@@ -5,7 +5,6 @@ package engine
 import (
 	"fmt"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/kopia/kopia/internal/clock"
@@ -15,7 +14,6 @@ import (
 type Log struct {
 	runOffset int
 	Log       []*LogEntry
-	mu        sync.RWMutex
 }
 
 // LogEntry is an entry for the engine log.
@@ -87,9 +85,6 @@ func (elog *Log) AddEntry(l *LogEntry) {
 // AddCompleted finalizes a log entry at the time it is called
 // and with the provided error, before adding it to the Log.
 func (elog *Log) AddCompleted(logEntry *LogEntry, err error) {
-	elog.mu.Lock()
-	defer elog.mu.Unlock()
-
 	logEntry.EndTime = clock.Now()
 	if err != nil {
 		logEntry.Error = err.Error()

--- a/tests/robustness/engine/log.go
+++ b/tests/robustness/engine/log.go
@@ -5,6 +5,7 @@ package engine
 import (
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/kopia/kopia/internal/clock"
@@ -14,6 +15,7 @@ import (
 type Log struct {
 	runOffset int
 	Log       []*LogEntry
+	mu        sync.RWMutex
 }
 
 // LogEntry is an entry for the engine log.
@@ -85,6 +87,9 @@ func (elog *Log) AddEntry(l *LogEntry) {
 // AddCompleted finalizes a log entry at the time it is called
 // and with the provided error, before adding it to the Log.
 func (elog *Log) AddCompleted(logEntry *LogEntry, err error) {
+	elog.mu.Lock()
+	defer elog.mu.Unlock()
+
 	logEntry.EndTime = clock.Now()
 	if err != nil {
 		logEntry.Error = err.Error()

--- a/tests/robustness/engine/stats.go
+++ b/tests/robustness/engine/stats.go
@@ -4,6 +4,7 @@ package engine
 
 import (
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
@@ -154,4 +155,66 @@ func (e *Engine) getTimestampS() int64 {
 
 func (e *Engine) getRuntimeSeconds() int64 {
 	return durationToSec(e.CumulativeStats.RunTime + clock.Since(e.RunStats.CreationTime))
+}
+
+type statsUpdatetype int
+
+const (
+	incrNoOp statsUpdatetype = iota
+	incrDataPurge
+	incrDataRestore
+	incrErrorRecovery
+)
+
+func (e *Engine) statsUpdateCounters(updateType statsUpdatetype) {
+	e.statsMux.Lock()
+	defer e.statsMux.Unlock()
+
+	switch updateType {
+	case incrNoOp:
+		e.RunStats.NoOpCount++
+		e.CumulativeStats.NoOpCount++
+	case incrDataPurge:
+		e.RunStats.DataPurgeCount++
+		e.CumulativeStats.DataPurgeCount++
+	case incrDataRestore:
+		e.RunStats.DataRestoreCount++
+		e.CumulativeStats.DataRestoreCount++
+	case incrErrorRecovery:
+		e.RunStats.ErrorRecoveryCount++
+		e.CumulativeStats.ErrorRecoveryCount++
+	}
+}
+
+func (e *Engine) statsIncrActionCountAndLog(actionKey ActionKey) {
+	e.statsMux.Lock()
+	defer e.statsMux.Unlock()
+
+	e.RunStats.ActionCounter++
+	e.CumulativeStats.ActionCounter++
+
+	log.Printf(
+		"Engine executing ACTION: name=%q actionCount=%v totActCount=%v t=%vs (%vs)",
+		actionKey,
+		e.RunStats.ActionCounter,
+		e.CumulativeStats.ActionCounter,
+		e.RunStats.getLifetimeSeconds(),
+		e.getRuntimeSeconds(),
+	)
+}
+
+func (e *Engine) statsUpdatePerAction(actionKey ActionKey, st time.Time, err error) {
+	e.statsMux.Lock()
+	defer e.statsMux.Unlock()
+
+	if e.RunStats.PerActionStats != nil && e.RunStats.PerActionStats[actionKey] == nil {
+		e.RunStats.PerActionStats[actionKey] = new(ActionStats)
+	}
+
+	if e.CumulativeStats.PerActionStats != nil && e.CumulativeStats.PerActionStats[actionKey] == nil {
+		e.CumulativeStats.PerActionStats[actionKey] = new(ActionStats)
+	}
+
+	e.RunStats.PerActionStats[actionKey].Record(st, err)
+	e.CumulativeStats.PerActionStats[actionKey].Record(st, err)
 }

--- a/tests/robustness/engine/stats.go
+++ b/tests/robustness/engine/stats.go
@@ -160,10 +160,10 @@ func (e *Engine) getRuntimeSeconds() int64 {
 type statsUpdatetype int
 
 const (
-	incrNoOp statsUpdatetype = iota
-	incrDataPurge
-	incrDataRestore
-	incrErrorRecovery
+	statsIncrNoOp statsUpdatetype = iota
+	statsIncrDataPurge
+	statsIncrDataRestore
+	statsIncrErrorRecovery
 )
 
 func (e *Engine) statsUpdateCounters(updateType statsUpdatetype) {
@@ -171,16 +171,16 @@ func (e *Engine) statsUpdateCounters(updateType statsUpdatetype) {
 	defer e.statsMux.Unlock()
 
 	switch updateType {
-	case incrNoOp:
+	case statsIncrNoOp:
 		e.RunStats.NoOpCount++
 		e.CumulativeStats.NoOpCount++
-	case incrDataPurge:
+	case statsIncrDataPurge:
 		e.RunStats.DataPurgeCount++
 		e.CumulativeStats.DataPurgeCount++
-	case incrDataRestore:
+	case statsIncrDataRestore:
 		e.RunStats.DataRestoreCount++
 		e.CumulativeStats.DataRestoreCount++
-	case incrErrorRecovery:
+	case statsIncrErrorRecovery:
 		e.RunStats.ErrorRecoveryCount++
 		e.CumulativeStats.ErrorRecoveryCount++
 	}

--- a/tests/robustness/engine/stats.go
+++ b/tests/robustness/engine/stats.go
@@ -5,6 +5,7 @@ package engine
 import (
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/kopia/kopia/internal/clock"
@@ -63,10 +64,15 @@ type Stats struct {
 	DataPurgeCount     int64
 	ErrorRecoveryCount int64
 	NoOpCount          int64
+
+	mu sync.RWMutex
 }
 
 // Stats returns a string report of the engine's stats.
 func (stats *Stats) Stats() string {
+	stats.mu.RLock()
+	defer stats.mu.RUnlock()
+
 	b := &strings.Builder{}
 
 	fmt.Fprintln(b, "=============")
@@ -95,6 +101,82 @@ func (stats *Stats) Stats() string {
 	}
 
 	return b.String()
+}
+
+// RecordAction records runtime statistics for an action.
+func (stats *Stats) RecordAction(actionKey ActionKey, st time.Time, err error) {
+	stats.mu.Lock()
+	defer stats.mu.Unlock()
+
+	if stats.PerActionStats != nil && stats.PerActionStats[actionKey] == nil {
+		stats.PerActionStats[actionKey] = new(ActionStats)
+	}
+
+	stats.PerActionStats[actionKey].Record(st, err)
+}
+
+// IncrementNoOpCount increments the no-op count.
+func (stats *Stats) IncrementNoOpCount() {
+	stats.mu.Lock()
+	defer stats.mu.Unlock()
+
+	stats.NoOpCount++
+}
+
+// IncrementActionCount increments the action count.
+func (stats *Stats) IncrementActionCount() {
+	stats.mu.Lock()
+	defer stats.mu.Unlock()
+
+	stats.ActionCounter++
+}
+
+// IncrementDataPurgeCount increments the data purge count.
+func (stats *Stats) IncrementDataPurgeCount() {
+	stats.mu.Lock()
+	defer stats.mu.Unlock()
+
+	stats.DataPurgeCount++
+}
+
+// IncrementDataRestoreCount increments the data restore count.
+func (stats *Stats) IncrementDataRestoreCount() {
+	stats.mu.Lock()
+	defer stats.mu.Unlock()
+
+	stats.DataRestoreCount++
+}
+
+// IncrementErrorRecoveryCount increments the error recovery count.
+func (stats *Stats) IncrementErrorRecoveryCount() {
+	stats.mu.Lock()
+	defer stats.mu.Unlock()
+
+	stats.ErrorRecoveryCount++
+}
+
+// GetActionCount gets the creation time.
+func (stats *Stats) GetActionCount() int64 {
+	stats.mu.RLock()
+	defer stats.mu.RUnlock()
+
+	return stats.ActionCounter
+}
+
+// GetCreationTime gets the creation time.
+func (stats *Stats) GetCreationTime() time.Time {
+	stats.mu.RLock()
+	defer stats.mu.RUnlock()
+
+	return stats.CreationTime
+}
+
+// GetRunTime gets the run time.
+func (stats *Stats) GetRunTime() time.Duration {
+	stats.mu.RLock()
+	defer stats.mu.RUnlock()
+
+	return stats.RunTime
 }
 
 // ActionStats tracks runtime statistics for an action.
@@ -133,7 +215,7 @@ func (s *ActionStats) Record(st time.Time, err error) {
 }
 
 func (stats *Stats) getLifetimeSeconds() int64 {
-	return durationToSec(clock.Since(stats.CreationTime))
+	return durationToSec(clock.Since(stats.GetCreationTime()))
 }
 
 func durationToSec(dur time.Duration) int64 {
@@ -153,5 +235,5 @@ func (e *Engine) getTimestampS() int64 {
 }
 
 func (e *Engine) getRuntimeSeconds() int64 {
-	return durationToSec(e.CumulativeStats.RunTime + clock.Since(e.RunStats.CreationTime))
+	return durationToSec(e.CumulativeStats.GetRunTime() + clock.Since(e.RunStats.GetCreationTime()))
 }


### PR DESCRIPTION
The multiclient robustness tests will have multiple clients calling `Engine.ExecAction` concurrently. The goal of this PR is to update the engine `Log` and `Stats` structs so that they can be safely accessed and modified from `Engine.ExecAction` concurrently.