### PR TITLE
add client-server utils for multiclient robustness

### DIFF
--- a/tests/robustness/snapmeta/kopia_persister.go
+++ b/tests/robustness/snapmeta/kopia_persister.go
@@ -94,13 +94,13 @@ const metadataStoreFileName = "metadata-store-latest"
 
 // ConnectOrCreateS3WithServer implements the RepoManager interface, creates a server
 // connects it a repo in an S3 bucket and creates a client to perform operations.
-func (store *KopiaPersister) ConnectOrCreateS3WithServer(serverAddr, bucketName, pathPrefix string) (*exec.Cmd, error) {
+func (store *KopiaPersister) ConnectOrCreateS3WithServer(serverAddr, bucketName, pathPrefix string) (*exec.Cmd, string, error) {
 	return store.snap.ConnectOrCreateS3WithServer(serverAddr, bucketName, pathPrefix)
 }
 
 // ConnectOrCreateFilesystemWithServer implements the RepoManager interface, creates a server
 // connects it a repo in the filesystem and creates a client to perform operations.
-func (store *KopiaPersister) ConnectOrCreateFilesystemWithServer(repoPath, serverAddr string) (*exec.Cmd, error) {
+func (store *KopiaPersister) ConnectOrCreateFilesystemWithServer(repoPath, serverAddr string) (*exec.Cmd, string, error) {
 	return store.snap.ConnectOrCreateFilesystemWithServer(repoPath, serverAddr)
 }
 

--- a/tests/robustness/snapmeta/kopia_snapshotter.go
+++ b/tests/robustness/snapmeta/kopia_snapshotter.go
@@ -5,6 +5,7 @@ package snapmeta
 import (
 	"context"
 	"io"
+	"log"
 	"os/exec"
 	"strconv"
 
@@ -48,9 +49,40 @@ func (ks *KopiaSnapshotter) ConnectOrCreateRepo(repoPath string) error {
 	return err
 }
 
+// ConnectClient should be called by a client to connect itself to the server
+// using the given cert fingerprint.
+func (ks *KopiaSnapshotter) ConnectClient(fingerprint, user string) error {
+	return ks.connectClient(fingerprint, user)
+}
+
+// DisconnectClient should be called by a client to disconnect itself from the server.
+func (ks *KopiaSnapshotter) DisconnectClient(user string) {
+	if err := ks.snap.DisconnectClient(); err != nil {
+		log.Printf("Error disconnecting %s from server: %v\n", user, err)
+	}
+}
+
+// AuthorizeClient should be called by a server to add a client to the server's
+// user list.
+func (ks *KopiaSnapshotter) AuthorizeClient(user string) error {
+	return ks.authorizeClient(user)
+}
+
+// RemoveClient should be called by a server to remove a client from its user list.
+func (ks *KopiaSnapshotter) RemoveClient(user string) {
+	if err := ks.snap.RemoveClient(user, defaultHost); err != nil {
+		log.Printf("Error removing %s from server: %v\n", user, err)
+	}
+}
+
 // ServerCmd returns the server command.
 func (ks *KopiaSnapshotter) ServerCmd() *exec.Cmd {
 	return ks.serverCmd
+}
+
+// ServerFingerprint returns the cert fingerprint that is used to connect to the server.
+func (ks *KopiaSnapshotter) ServerFingerprint() string {
+	return ks.serverFingerprint
 }
 
 // CreateSnapshot is part of Snapshotter.


### PR DESCRIPTION
Update `KopiaSnapshotter` and related components to add or modify utilities for connecting multiple clients to a single Kopia server. At a high level the changes include the following:
- Break up server creation and client connection actions that were both previously contained in `createAndConnectServer`.
- Add utilities to manage and authorize clients using the `kopia server user` commands that were added in v0.8.
- Add ability to set more permissive snapshot access rules that are required for multiclient robustness testing. This uses the `kopia server acl` commands that were added in v0.8.