### PR TITLE
Use testing.T for parallel robustness tests

### DIFF
--- a/tests/robustness/multiclient_test/README.md
+++ b/tests/robustness/multiclient_test/README.md
@@ -34,7 +34,9 @@ func TestExample(t *testing.T) {
 	numClients := 4
 
 	// Define per-client test actions
-	f := func(ctx context.Context) {
+	f := func(ctx context.Context, t *testing.T) {
+		t.Helper()
+
 		_, err := eng.ExecAction(ctx, /* engine-action-key */, /* opts */)
 		// ... other actions ...
 	}
@@ -43,6 +45,6 @@ func TestExample(t *testing.T) {
 	ctx := testlogging.Context(t)
 
 	// Run test actions for each client concurrently
-	th.RunN(ctx, numClients, f)
+	th.RunN(ctx, t, numClients, f)
 }
 ```

--- a/tests/robustness/multiclient_test/framework/harness.go
+++ b/tests/robustness/multiclient_test/framework/harness.go
@@ -208,7 +208,11 @@ func (th *TestHarness) Engine() *engine.Engine {
 
 // Run runs the provided function asynchronously for each of the given client
 // contexts, waits for all of them to finish, and optionally cleans up clients.
-func (th *TestHarness) Run(t *testing.T, ctxs []context.Context, cleanup bool, f func(context.Context, *testing.T)) {
+func (th *TestHarness) Run( // nolint:thelper
+	ctxs []context.Context,
+	t *testing.T, cleanup bool,
+	f func(context.Context, *testing.T),
+) {
 	t.Helper()
 
 	t.Run("group", func(t *testing.T) {
@@ -236,11 +240,16 @@ func (th *TestHarness) Run(t *testing.T, ctxs []context.Context, cleanup bool, f
 
 // RunN creates client contexts, runs the provided function asynchronously for
 // each client, waits for all of them to finish, and cleans up clients.
-func (th *TestHarness) RunN(ctx context.Context, t *testing.T, numClients int, f func(context.Context, *testing.T)) {
+func (th *TestHarness) RunN(
+	ctx context.Context,
+	t *testing.T,
+	numClients int,
+	f func(context.Context, *testing.T),
+) {
 	t.Helper()
 
 	ctxs := NewClientContexts(ctx, numClients)
-	th.Run(t, ctxs, true, f)
+	th.Run(ctxs, t, true, f)
 }
 
 // Cleanup shuts down the engine and stops the test app. It requires a context

--- a/tests/robustness/multiclient_test/framework/harness.go
+++ b/tests/robustness/multiclient_test/framework/harness.go
@@ -6,12 +6,13 @@ import (
 	"context"
 	"errors"
 	"flag"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
 	"path"
-	"sync"
 	"syscall"
+	"testing"
 
 	"github.com/kopia/kopia/tests/robustness/engine"
 	"github.com/kopia/kopia/tests/robustness/fiofilewriter"
@@ -207,31 +208,39 @@ func (th *TestHarness) Engine() *engine.Engine {
 
 // Run runs the provided function asynchronously for each of the given client
 // contexts, waits for all of them to finish, and optionally cleans up clients.
-func (th *TestHarness) Run(ctxs []context.Context, cleanup bool, f func(context.Context)) {
-	var wg sync.WaitGroup
+func (th *TestHarness) Run(t *testing.T, ctxs []context.Context, cleanup bool, f func(context.Context, *testing.T)) {
+	t.Helper()
 
-	for _, ctx := range ctxs {
-		wg.Add(1)
+	t.Run("group", func(t *testing.T) {
+		testNum := 0
 
-		go func(ctx context.Context) {
-			f(ctx)
+		for _, ctx := range ctxs {
+			ctx := ctx
+			testNum++
 
-			if cleanup {
-				th.snapshotter.CleanupClient(ctx)
-			}
+			t.Run(fmt.Sprint(testNum), func(t *testing.T) {
+				t.Parallel()
+				f(ctx, t)
+			})
+		}
+	})
 
-			wg.Done()
-		}(ctx)
+	if !cleanup {
+		return
 	}
 
-	wg.Wait()
+	for _, ctx := range ctxs {
+		th.snapshotter.CleanupClient(ctx)
+	}
 }
 
 // RunN creates client contexts, runs the provided function asynchronously for
 // each client, waits for all of them to finish, and cleans up clients.
-func (th *TestHarness) RunN(ctx context.Context, numClients int, f func(context.Context)) {
+func (th *TestHarness) RunN(ctx context.Context, t *testing.T, numClients int, f func(context.Context, *testing.T)) {
+	t.Helper()
+
 	ctxs := NewClientContexts(ctx, numClients)
-	th.Run(ctxs, true, f)
+	th.Run(t, ctxs, true, f)
 }
 
 // Cleanup shuts down the engine and stops the test app. It requires a context

--- a/tests/robustness/multiclient_test/framework/snapshotter.go
+++ b/tests/robustness/multiclient_test/framework/snapshotter.go
@@ -159,6 +159,10 @@ func (mcs *MultiClientSnapshotter) CleanupClient(ctx context.Context) {
 	delete(mcs.clients, c.ID)
 	mcs.mu.Unlock()
 
+	if s == nil {
+		return
+	}
+
 	s.DisconnectClient(c.ID)
 	s.Cleanup()
 	mcs.server.RemoveClient(c.ID)

--- a/tests/robustness/multiclient_test/multiclient_test.go
+++ b/tests/robustness/multiclient_test/multiclient_test.go
@@ -36,7 +36,9 @@ func TestManySmallFiles(t *testing.T) {
 		fiofilewriter.MinNumFilesPerWriteField: strconv.Itoa(numFiles),
 	}
 
-	f := func(ctx context.Context) {
+	f := func(ctx context.Context, t *testing.T) {
+		t.Helper()
+
 		err := tryRestoreIntoDataDirectory(ctx, t)
 		testenv.AssertNoError(t, err)
 
@@ -51,7 +53,7 @@ func TestManySmallFiles(t *testing.T) {
 	}
 
 	ctx := testlogging.Context(t)
-	th.RunN(ctx, numClients, f)
+	th.RunN(ctx, t, numClients, f)
 }
 
 func TestOneLargeFile(t *testing.T) {
@@ -67,7 +69,9 @@ func TestOneLargeFile(t *testing.T) {
 		fiofilewriter.MinNumFilesPerWriteField: strconv.Itoa(numFiles),
 	}
 
-	f := func(ctx context.Context) {
+	f := func(ctx context.Context, t *testing.T) {
+		t.Helper()
+
 		err := tryRestoreIntoDataDirectory(ctx, t)
 		testenv.AssertNoError(t, err)
 
@@ -82,7 +86,7 @@ func TestOneLargeFile(t *testing.T) {
 	}
 
 	ctx := testlogging.Context(t)
-	th.RunN(ctx, numClients, f)
+	th.RunN(ctx, t, numClients, f)
 }
 
 func TestManySmallFilesAcrossDirecoryTree(t *testing.T) {
@@ -102,7 +106,9 @@ func TestManySmallFilesAcrossDirecoryTree(t *testing.T) {
 		engine.ActionRepeaterField:             strconv.Itoa(actionRepeats),
 	}
 
-	f := func(ctx context.Context) {
+	f := func(ctx context.Context, t *testing.T) {
+		t.Helper()
+
 		err := tryRestoreIntoDataDirectory(ctx, t)
 		testenv.AssertNoError(t, err)
 
@@ -117,7 +123,7 @@ func TestManySmallFilesAcrossDirecoryTree(t *testing.T) {
 	}
 
 	ctx := testlogging.Context(t)
-	th.RunN(ctx, numClients, f)
+	th.RunN(ctx, t, numClients, f)
 }
 
 func TestRandomizedSmall(t *testing.T) {
@@ -140,7 +146,9 @@ func TestRandomizedSmall(t *testing.T) {
 		},
 	}
 
-	f := func(ctx context.Context) {
+	f := func(ctx context.Context, t *testing.T) {
+		t.Helper()
+
 		err := tryRestoreIntoDataDirectory(ctx, t)
 		testenv.AssertNoError(t, err)
 
@@ -151,10 +159,10 @@ func TestRandomizedSmall(t *testing.T) {
 	}
 
 	ctx := testlogging.Context(t)
-	th.RunN(ctx, numClients, f)
+	th.RunN(ctx, t, numClients, f)
 }
 
-// tryExecAction runs eng.ExecAction on the given parameters and masks no-op errors.
+// tryRestoreIntoDataDirectory runs eng.ExecAction on the given parameters and masks no-op errors.
 func tryRestoreIntoDataDirectory(ctx context.Context, t *testing.T) error {
 	t.Helper()
 


### PR DESCRIPTION
Update multi-client robustness test harness to use the parallel `Run` functionality included in the `testing` package.

This fixes an issue where the robustness test could get stuck waiting for a failed test to complete.