### PR TITLE
Implement new persister

### DIFF
--- a/tests/robustness/persister.go
+++ b/tests/robustness/persister.go
@@ -7,7 +7,7 @@ package robustness
 type Store interface {
 	Store(key string, val []byte) error
 	Load(key string) ([]byte, error)
-	Delete(key string)
+	Delete(key string) error
 }
 
 // Persister describes the ability to flush metadata

--- a/tests/robustness/snapmeta/kopia_persister_light.go
+++ b/tests/robustness/snapmeta/kopia_persister_light.go
@@ -88,16 +88,15 @@ func (kpl *KopiaPersisterLight) Load(key string) ([]byte, error) {
 }
 
 // Delete deletes all snapshots associated with the given key.
-func (kpl *KopiaPersisterLight) Delete(key string) {
+func (kpl *KopiaPersisterLight) Delete(key string) error {
 	kpl.waitFor(key)
 	defer kpl.doneWith(key)
 
 	log.Println("deleting metadata for", key)
 
 	dirPath, _ := kpl.getPathsFromKey(key)
-	if err := kpl.kc.SnapshotDelete(context.Background(), dirPath); err != nil {
-		log.Printf("cannot delete metadata for %s, err: %s", key, err)
-	}
+
+	return kpl.kc.SnapshotDelete(context.Background(), dirPath)
 }
 
 // LoadMetadata is a no-op. It is included to satisfy the Persister interface.

--- a/tests/robustness/snapmeta/kopia_persister_light.go
+++ b/tests/robustness/snapmeta/kopia_persister_light.go
@@ -62,11 +62,13 @@ func (kpl *KopiaPersisterLight) Store(key string, val []byte) error {
 		return err
 	}
 
-	defer kpl.removeOrLog(dirPath)
-
 	log.Println("pushing metadata for", key)
 
-	return kpl.kc.SnapshotCreate(context.Background(), dirPath)
+	if err := kpl.kc.SnapshotCreate(context.Background(), dirPath); err != nil {
+		return err
+	}
+
+	return os.RemoveAll(dirPath)
 }
 
 // Load pulls the key value pair from the Kopia repo and returns the value.
@@ -82,9 +84,16 @@ func (kpl *KopiaPersisterLight) Load(key string) ([]byte, error) {
 		return nil, err
 	}
 
-	defer kpl.removeOrLog(dirPath)
+	val, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, err
+	}
 
-	return os.ReadFile(filePath)
+	if err := os.RemoveAll(dirPath); err != nil {
+		return nil, err
+	}
+
+	return val, nil
 }
 
 // Delete deletes all snapshots associated with the given key.
@@ -126,12 +135,6 @@ func (kpl *KopiaPersisterLight) getPathsFromKey(key string) (dirPath, filePath s
 	filePath = filepath.Join(dirPath, fileName)
 
 	return dirPath, filePath
-}
-
-func (kpl *KopiaPersisterLight) removeOrLog(path string) {
-	if err := os.RemoveAll(path); err != nil {
-		log.Println("cannot remove path ", path)
-	}
 }
 
 func (kpl *KopiaPersisterLight) waitFor(key string) {

--- a/tests/robustness/snapmeta/kopia_persister_light.go
+++ b/tests/robustness/snapmeta/kopia_persister_light.go
@@ -22,10 +22,6 @@ type KopiaPersisterLight struct {
 	baseDir       string
 }
 
-type kmu struct {
-	mu sync.Mutex
-}
-
 var _ robustness.Persister = (*KopiaPersisterLight)(nil)
 
 const fileName = "data"

--- a/tests/robustness/snapmeta/kopia_persister_light.go
+++ b/tests/robustness/snapmeta/kopia_persister_light.go
@@ -1,0 +1,157 @@
+// +build darwin,amd64 linux,amd64
+
+package snapmeta
+
+import (
+	"context"
+	"log"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/kopia/kopia/tests/robustness"
+	"github.com/kopia/kopia/tests/tools/kopiaclient"
+)
+
+// KopiaPersisterLight is a wrapper for KopiaClient that satisfies the Persister
+// interface.
+type KopiaPersisterLight struct {
+	kc            *kopiaclient.KopiaClient
+	keysInProcess map[string]bool
+	c             *sync.Cond
+	baseDir       string
+}
+
+type kmu struct {
+	mu sync.Mutex
+}
+
+var _ robustness.Persister = (*KopiaPersisterLight)(nil)
+
+const fileName = "data"
+
+// NewPersisterLight returns a new KopiaPersisterLight.
+func NewPersisterLight(baseDir string) (*KopiaPersisterLight, error) {
+	persistenceDir, err := os.MkdirTemp(baseDir, "kopia-persistence-root-")
+	if err != nil {
+		return nil, err
+	}
+
+	return &KopiaPersisterLight{
+		kc:            kopiaclient.NewKopiaClient(persistenceDir),
+		keysInProcess: map[string]bool{},
+		c:             sync.NewCond(&sync.Mutex{}),
+		baseDir:       persistenceDir,
+	}, nil
+}
+
+// ConnectOrCreateRepo creates a new Kopia repo or connects to an existing one if possible.
+func (kpl *KopiaPersisterLight) ConnectOrCreateRepo(repoPath string) error {
+	bucketName := os.Getenv(S3BucketNameEnvKey)
+	return kpl.kc.CreateOrConnectRepo(context.Background(), repoPath, bucketName)
+}
+
+// Store pushes the key value pair to the Kopia repository.
+func (kpl *KopiaPersisterLight) Store(key string, val []byte) error {
+	kpl.waitFor(key)
+	defer kpl.doneWith(key)
+
+	dirPath, filePath := kpl.getPathsFromKey(key)
+
+	if err := os.Mkdir(dirPath, 0o700); err != nil {
+		return err
+	}
+
+	if err := os.WriteFile(filePath, val, 0o700); err != nil {
+		return err
+	}
+
+	defer kpl.removeOrLog(dirPath)
+
+	log.Println("pushing metadata for", key)
+
+	return kpl.kc.SnapshotCreate(context.Background(), dirPath)
+}
+
+// Load pulls the key value pair from the Kopia repo and returns the value.
+func (kpl *KopiaPersisterLight) Load(key string) ([]byte, error) {
+	kpl.waitFor(key)
+	defer kpl.doneWith(key)
+
+	dirPath, filePath := kpl.getPathsFromKey(key)
+
+	log.Println("pulling metadata for", key)
+
+	if err := kpl.kc.SnapshotRestore(context.Background(), dirPath); err != nil {
+		return nil, err
+	}
+
+	defer kpl.removeOrLog(dirPath)
+
+	return os.ReadFile(filePath)
+}
+
+// Delete deletes all snapshots associated with the given key.
+func (kpl *KopiaPersisterLight) Delete(key string) {
+	kpl.waitFor(key)
+	defer kpl.doneWith(key)
+
+	log.Println("deleting metadata for", key)
+
+	dirPath, _ := kpl.getPathsFromKey(key)
+	if err := kpl.kc.SnapshotDelete(context.Background(), dirPath); err != nil {
+		log.Printf("cannot delete metadata for %s, err: %s", key, err)
+	}
+}
+
+// LoadMetadata is a no-op. It is included to satisfy the Persister interface.
+func (kpl *KopiaPersisterLight) LoadMetadata() error {
+	return nil
+}
+
+// FlushMetadata is a no-op. It is included to satisfy the Persister interface.
+func (kpl *KopiaPersisterLight) FlushMetadata() error {
+	return nil
+}
+
+// GetPersistDir returns the persistence directory.
+func (kpl *KopiaPersisterLight) GetPersistDir() string {
+	return kpl.baseDir
+}
+
+// Cleanup removes the persistence directory and closes the Kopia repo.
+func (kpl *KopiaPersisterLight) Cleanup() {
+	if err := os.RemoveAll(kpl.baseDir); err != nil {
+		log.Println("cannot remove persistence dir")
+	}
+}
+
+func (kpl *KopiaPersisterLight) getPathsFromKey(key string) (dirPath, filePath string) {
+	dirPath = filepath.Join(kpl.baseDir, key)
+	filePath = filepath.Join(dirPath, fileName)
+
+	return dirPath, filePath
+}
+
+func (kpl *KopiaPersisterLight) removeOrLog(path string) {
+	if err := os.RemoveAll(path); err != nil {
+		log.Println("cannot remove path ", path)
+	}
+}
+
+func (kpl *KopiaPersisterLight) waitFor(key string) {
+	kpl.c.L.Lock()
+	for kpl.keysInProcess[key] {
+		kpl.c.Wait()
+	}
+
+	kpl.keysInProcess[key] = true
+	kpl.c.L.Unlock()
+}
+
+func (kpl *KopiaPersisterLight) doneWith(key string) {
+	kpl.c.L.Lock()
+	delete(kpl.keysInProcess, key)
+	kpl.c.L.Unlock()
+	kpl.c.Signal()
+}

--- a/tests/robustness/snapmeta/kopia_persister_light_test.go
+++ b/tests/robustness/snapmeta/kopia_persister_light_test.go
@@ -40,15 +40,19 @@ func TestConcurrency(t *testing.T) {
 	keys := []string{"key1", "key2", "key3"}
 	vals := [][]byte{[]byte("val1"), []byte("val2"), []byte("val3")}
 
-	t.Run("group", func(t *testing.T) {
+	t.Run("storeLoad", func(t *testing.T) {
 		for i := 0; i < 9; i++ {
 			j := i
-
 			t.Run(fmt.Sprint(i), func(t *testing.T) {
 				t.Parallel()
 				kpl.testStoreLoad(t, keys[j%3], vals[j%3])
 			})
+		}
+	})
 
+	t.Run("delete", func(t *testing.T) {
+		for i := 0; i < 9; i++ {
+			j := i
 			t.Run(fmt.Sprint(i), func(t *testing.T) {
 				t.Parallel()
 				kpl.testDelete(t, keys[j%3], vals[j%3])

--- a/tests/robustness/snapmeta/kopia_persister_light_test.go
+++ b/tests/robustness/snapmeta/kopia_persister_light_test.go
@@ -25,7 +25,7 @@ func TestStoreLoadDelete(t *testing.T) {
 	defer kpl.Cleanup()
 
 	kpl.testStoreLoad(t, key, val)
-	kpl.testDelete(t, key, val)
+	kpl.testDelete(t, key)
 }
 
 func TestConcurrency(t *testing.T) {
@@ -55,14 +55,14 @@ func TestConcurrency(t *testing.T) {
 			j := i
 			t.Run(fmt.Sprint(i), func(t *testing.T) {
 				t.Parallel()
-				kpl.testDelete(t, keys[j%3], vals[j%3])
+				kpl.testDelete(t, keys[j%3])
 			})
 		}
 	})
 }
 
 // Store and test that subsequent Load succeeds.
-func (kpl *KopiaPersisterLight) testStoreLoad(t *testing.T, key string, val []byte) {
+func (kpl *KopiaPersisterLight) testStoreLoad(t *testing.T, key string, val []byte) { //nolint:thelper
 	err := kpl.Store(key, val)
 	assertNoError(t, err)
 
@@ -75,7 +75,7 @@ func (kpl *KopiaPersisterLight) testStoreLoad(t *testing.T, key string, val []by
 }
 
 // Delete and test that subsequent Load fails.
-func (kpl *KopiaPersisterLight) testDelete(t *testing.T, key string, val []byte) {
+func (kpl *KopiaPersisterLight) testDelete(t *testing.T, key string) { //nolint:thelper
 	kpl.Delete(key)
 
 	_, err := kpl.Load(key)
@@ -111,9 +111,7 @@ func TestPersistence(t *testing.T) {
 	os.RemoveAll(repoPath)
 }
 
-func initKPL(t *testing.T, repoPath string) *KopiaPersisterLight {
-	t.Helper()
-
+func initKPL(t *testing.T, repoPath string) *KopiaPersisterLight { //nolint:thelper
 	os.Unsetenv(S3BucketNameEnvKey)
 
 	kpl, err := NewPersisterLight("")

--- a/tests/robustness/snapmeta/kopia_persister_light_test.go
+++ b/tests/robustness/snapmeta/kopia_persister_light_test.go
@@ -1,0 +1,130 @@
+// +build darwin,amd64 linux,amd64
+
+package snapmeta
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"os"
+	"testing"
+)
+
+var (
+	key = "mykey"
+	val = []byte("myval")
+)
+
+func TestStoreLoadDelete(t *testing.T) {
+	repoPath, err := os.MkdirTemp("", "kopia-test-repo-")
+	assertNoError(t, err)
+
+	defer os.RemoveAll(repoPath)
+
+	kpl := initKPL(t, repoPath)
+	defer kpl.Cleanup()
+
+	kpl.testStoreLoad(t, key, val)
+	kpl.testDelete(t, key, val)
+}
+
+func TestConcurrency(t *testing.T) {
+	repoPath, err := os.MkdirTemp("", "kopia-test-repo-")
+	assertNoError(t, err)
+
+	defer os.RemoveAll(repoPath)
+
+	kpl := initKPL(t, repoPath)
+	defer kpl.Cleanup()
+
+	keys := []string{"key1", "key2", "key3"}
+	vals := [][]byte{[]byte("val1"), []byte("val2"), []byte("val3")}
+
+	t.Run("group", func(t *testing.T) {
+		for i := 0; i < 9; i++ {
+			j := i
+
+			t.Run(fmt.Sprint(i), func(t *testing.T) {
+				t.Parallel()
+				kpl.testStoreLoad(t, keys[j%3], vals[j%3])
+			})
+
+			t.Run(fmt.Sprint(i), func(t *testing.T) {
+				t.Parallel()
+				kpl.testDelete(t, keys[j%3], vals[j%3])
+			})
+		}
+	})
+}
+
+// Store and test that subsequent Load succeeds.
+func (kpl *KopiaPersisterLight) testStoreLoad(t *testing.T, key string, val []byte) {
+	err := kpl.Store(key, val)
+	assertNoError(t, err)
+
+	valOut, err := kpl.Load(key)
+	assertNoError(t, err)
+
+	if !bytes.Equal(valOut, val) {
+		t.Fatal("loaded value does not equal stored value")
+	}
+}
+
+// Delete and test that subsequent Load fails.
+func (kpl *KopiaPersisterLight) testDelete(t *testing.T, key string, val []byte) {
+	kpl.Delete(key)
+
+	_, err := kpl.Load(key)
+	log.Println("err:", err)
+
+	if err == nil {
+		t.Fatal("snapshot was not deleted properly")
+	}
+}
+
+func TestPersistence(t *testing.T) {
+	repoPath, err := os.MkdirTemp("", "kopia-test-repo-")
+	assertNoError(t, err)
+
+	kpl := initKPL(t, repoPath)
+
+	// Store and cleanup kpl
+	err = kpl.Store(key, val)
+	assertNoError(t, err)
+
+	kpl.Cleanup()
+
+	// Re-initialize and Load
+	kpl = initKPL(t, repoPath)
+	valOut, err := kpl.Load(key)
+	assertNoError(t, err)
+
+	if !bytes.Equal(valOut, val) {
+		t.Fatal("loaded value does not equal stored value")
+	}
+
+	kpl.Cleanup()
+	os.RemoveAll(repoPath)
+}
+
+func initKPL(t *testing.T, repoPath string) *KopiaPersisterLight {
+	t.Helper()
+
+	os.Unsetenv(S3BucketNameEnvKey)
+
+	kpl, err := NewPersisterLight("")
+	assertNoError(t, err)
+
+	err = kpl.ConnectOrCreateRepo(repoPath)
+	assertNoError(t, err)
+
+	return kpl
+}
+
+func assertNoError(t *testing.T, err error) {
+	t.Helper()
+
+	if err != nil {
+		t.Errorf("err: %v", err)
+	}
+}

--- a/tests/robustness/snapmeta/simple.go
+++ b/tests/robustness/snapmeta/simple.go
@@ -46,6 +46,8 @@ func (s *Simple) Load(key string) ([]byte, error) {
 }
 
 // Delete implements the Storer interface Delete method.
-func (s *Simple) Delete(key string) {
+func (s *Simple) Delete(key string) error {
 	delete(s.Data, key)
+
+	return nil
 }

--- a/tests/tools/kopiaclient/kopiaclient.go
+++ b/tests/tools/kopiaclient/kopiaclient.go
@@ -1,0 +1,245 @@
+// +build darwin,amd64 linux,amd64
+
+// Package kopiaclient provides a client to interact with a Kopia repo.
+package kopiaclient
+
+import (
+	"context"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/fs/localfs"
+	"github.com/kopia/kopia/internal/units"
+	"github.com/kopia/kopia/repo"
+	"github.com/kopia/kopia/repo/blob"
+	"github.com/kopia/kopia/repo/blob/filesystem"
+	"github.com/kopia/kopia/repo/blob/s3"
+	"github.com/kopia/kopia/snapshot"
+	"github.com/kopia/kopia/snapshot/policy"
+	"github.com/kopia/kopia/snapshot/restore"
+	"github.com/kopia/kopia/snapshot/snapshotfs"
+	"github.com/kopia/kopia/tests/robustness"
+)
+
+// KopiaClient uses a Kopia repo to create, restore, and delete snapshots.
+type KopiaClient struct {
+	configPath string
+	pw         string
+}
+
+const (
+	configFileName           = "config"
+	password                 = "kj13498po&_EXAMPLE" //nolint:gosec
+	s3Endpoint               = "s3.amazonaws.com"
+	awsAccessKeyIDEnvKey     = "AWS_ACCESS_KEY_ID"
+	awsSecretAccessKeyEnvKey = "AWS_SECRET_ACCESS_KEY" //nolint:gosec
+)
+
+// NewKopiaClient returns a new KopiaClient.
+func NewKopiaClient(basePath string) *KopiaClient {
+	return &KopiaClient{
+		configPath: filepath.Join(basePath, configFileName),
+		pw:         password,
+	}
+}
+
+// CreateOrConnectRepo creates a new Kopia repo or connects to an existing one if possible.
+func (kc *KopiaClient) CreateOrConnectRepo(ctx context.Context, repoDir, bucketName string) error {
+	st, err := kc.getStorage(ctx, repoDir, bucketName)
+	if err != nil {
+		return err
+	}
+
+	if iErr := repo.Initialize(ctx, st, &repo.NewRepositoryOptions{}, kc.pw); iErr != nil {
+		if !errors.Is(iErr, repo.ErrAlreadyInitialized) {
+			return errors.Wrap(iErr, "repo is already initialized")
+		}
+
+		log.Println("connecting to existing repository")
+	}
+
+	if iErr := repo.Connect(ctx, kc.configPath, st, kc.pw, &repo.ConnectOptions{}); iErr != nil {
+		return errors.Wrap(iErr, "error connecting to repository")
+	}
+
+	return errors.Wrap(err, "unable to open repository")
+}
+
+// SnapshotCreate creates a snapshot for the given path.
+func (kc *KopiaClient) SnapshotCreate(ctx context.Context, path string) error {
+	r, err := repo.Open(ctx, kc.configPath, kc.pw, &repo.Options{})
+	if err != nil {
+		return errors.Wrap(err, "cannot get new repository writer")
+	}
+
+	rw, err := r.NewWriter(ctx, repo.WriteSessionOptions{})
+	if err != nil {
+		return errors.Wrap(err, "cannot get new repository writer")
+	}
+
+	si, err := kc.getSourceInfoFromPath(r, filepath.Base(path))
+	if err != nil {
+		return errors.Wrap(err, "cannot get source info from path")
+	}
+
+	policyTree, err := policy.TreeForSource(ctx, r, si)
+	if err != nil {
+		return errors.Wrap(err, "cannot get policy tree for source")
+	}
+
+	source, err := localfs.NewEntry(path)
+	if err != nil {
+		return errors.Wrap(err, "cannot get filesystem entry from path")
+	}
+
+	u := snapshotfs.NewUploader(rw)
+
+	man, err := u.Upload(ctx, source, policyTree, si)
+	if err != nil {
+		return errors.Wrap(err, "cannot get manifest")
+	}
+
+	log.Printf("snapshotting %v", units.BytesStringBase10(man.Stats.TotalFileSize))
+
+	if _, err := snapshot.SaveSnapshot(ctx, rw, man); err != nil {
+		return errors.Wrap(err, "cannot save snapshot")
+	}
+
+	if err := rw.Flush(ctx); err != nil {
+		return err
+	}
+
+	return r.Close(ctx)
+}
+
+// SnapshotRestore restores the latests snapshot for the given path.
+func (kc *KopiaClient) SnapshotRestore(ctx context.Context, path string) error {
+	r, err := repo.Open(ctx, kc.configPath, kc.pw, &repo.Options{})
+	if err != nil {
+		return errors.Wrap(err, "cannot get new repository writer")
+	}
+
+	mans, err := kc.getSnapshotsFromPath(ctx, r, filepath.Base(path))
+	if err != nil {
+		return err
+	}
+
+	man := kc.latestManifest(mans)
+
+	rootEntry, err := snapshotfs.FilesystemEntryFromIDWithPath(ctx, r, string(man.ID), false)
+	if err != nil {
+		return errors.Wrap(err, "cannot get filesystem entry from ID with path")
+	}
+
+	output := &restore.FilesystemOutput{TargetPath: path}
+
+	st, err := restore.Entry(ctx, r, output, rootEntry, restore.Options{})
+	if err != nil {
+		return errors.Wrap(err, "cannot restore snapshot")
+	}
+
+	log.Printf("restored %v", units.BytesStringBase10(st.RestoredTotalFileSize))
+
+	return r.Close(ctx)
+}
+
+// SnapshotDelete deletes all snapshots for a given path.
+func (kc *KopiaClient) SnapshotDelete(ctx context.Context, path string) error {
+	r, err := repo.Open(ctx, kc.configPath, kc.pw, &repo.Options{})
+	if err != nil {
+		return errors.Wrap(err, "cannot get new repository writer")
+	}
+
+	rw, err := r.NewWriter(ctx, repo.WriteSessionOptions{})
+	if err != nil {
+		return errors.Wrap(err, "cannot get new repository writer")
+	}
+
+	mans, err := kc.getSnapshotsFromPath(ctx, r, filepath.Base(path))
+	if err != nil {
+		return err
+	}
+
+	for _, man := range mans {
+		err = rw.DeleteManifest(ctx, man.ID)
+		if err != nil {
+			return errors.Wrap(err, "cannot delete manifest")
+		}
+	}
+
+	if err := rw.Flush(ctx); err != nil {
+		return err
+	}
+
+	return r.Close(ctx)
+}
+
+func (kc *KopiaClient) getStorage(ctx context.Context, repoDir, bucketName string) (st blob.Storage, err error) {
+	if bucketName != "" {
+		s3Opts := &s3.Options{
+			BucketName:      bucketName,
+			Prefix:          repoDir,
+			Endpoint:        s3Endpoint,
+			AccessKeyID:     os.Getenv(awsAccessKeyIDEnvKey),
+			SecretAccessKey: os.Getenv(awsSecretAccessKeyEnvKey),
+		}
+		st, err = s3.New(ctx, s3Opts)
+	} else {
+		if iErr := os.MkdirAll(repoDir, 0o700); iErr != nil {
+			return nil, errors.Wrap(iErr, "cannot create directory")
+		}
+
+		fsOpts := &filesystem.Options{
+			Path: repoDir,
+		}
+		st, err = filesystem.New(ctx, fsOpts)
+	}
+
+	return st, errors.Wrap(err, "unable to get storage")
+}
+
+func (kc *KopiaClient) getSnapshotsFromPath(ctx context.Context, r repo.Repository, path string) ([]*snapshot.Manifest, error) {
+	si, err := kc.getSourceInfoFromPath(r, path)
+	if err != nil {
+		return nil, err
+	}
+
+	manifests, err := snapshot.ListSnapshots(ctx, r, si)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot list snapshots")
+	}
+
+	if len(manifests) == 0 {
+		return nil, robustness.ErrKeyNotFound
+	}
+
+	return manifests, nil
+}
+
+func (kc *KopiaClient) getSourceInfoFromPath(r repo.Repository, path string) (snapshot.SourceInfo, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return snapshot.SourceInfo{}, errors.Wrap(err, "cannot get absolute path")
+	}
+
+	return snapshot.SourceInfo{
+		Host:     r.ClientOptions().Hostname,
+		UserName: r.ClientOptions().Username,
+		Path:     absPath,
+	}, nil
+}
+
+func (kc *KopiaClient) latestManifest(mans []*snapshot.Manifest) *snapshot.Manifest {
+	latest := mans[0]
+
+	for _, m := range mans {
+		if m.StartTime.After(latest.StartTime) {
+			latest = m
+		}
+	}
+
+	return latest
+}


### PR DESCRIPTION
Implement new persister for robustness tests. The existing persister stores metadata for all snapshots in one data structure that is flushed to the Kopia repository. Instead, this new persister implementation immediately pushes and pulls metadata to and from the Kopia repo.

Part 2 of 5:
1. #201 Implement Kopia API client
2. #202 Implement new persister
3. #203 Robustness test updates
4. #204 Add context to store interface 
5. #205 Push robustness metadata without writing to fs