### PR TITLE
CLI changes to allow updating blob-retention parameters for a repository

### DIFF
--- a/cli/command_repository_create.go
+++ b/cli/command_repository_create.go
@@ -2,8 +2,10 @@ package cli
 
 import (
 	"context"
+	"time"
 
 	"github.com/alecthomas/kingpin"
+	"github.com/minio/minio-go/v7"
 	"github.com/pkg/errors"
 
 	"github.com/kopia/kopia/repo"
@@ -28,6 +30,8 @@ type commandRepositoryCreate struct {
 	createSplitter              string
 	createOnly                  bool
 	createFormatVersion         int
+	retentionMode               string
+	retentionPeriod             time.Duration
 
 	co  connectOptions
 	svc advancedAppServices
@@ -42,6 +46,8 @@ func (c *commandRepositoryCreate) setup(svc advancedAppServices, parent commandP
 	cmd.Flag("object-splitter", "The splitter to use for new objects in the repository").Default(splitter.DefaultAlgorithm).EnumVar(&c.createSplitter, splitter.SupportedAlgorithms()...)
 	cmd.Flag("create-only", "Create repository, but don't connect to it.").Short('c').BoolVar(&c.createOnly)
 	cmd.Flag("format-version", "Force a particular repository format version (1 or 2, 0==default)").IntVar(&c.createFormatVersion)
+	cmd.Flag("retention-mode", "Set the blob retention-mode for supported storage backends.").EnumVar(&c.retentionMode, minio.Governance.String(), minio.Compliance.String())
+	cmd.Flag("retention-period", "Set the blob retention-period for supported storage backends.").DurationVar(&c.retentionPeriod)
 
 	c.co.setup(cmd)
 	c.svc = svc
@@ -81,6 +87,9 @@ func (c *commandRepositoryCreate) newRepositoryOptionsFromFlags() *repo.NewRepos
 		ObjectFormat: object.Format{
 			Splitter: c.createSplitter,
 		},
+
+		RetentionMode:   c.retentionMode,
+		RetentionPeriod: c.retentionPeriod,
 	}
 }
 

--- a/internal/blobtesting/versionedmap.go
+++ b/internal/blobtesting/versionedmap.go
@@ -1,0 +1,248 @@
+package blobtesting
+
+import (
+	"bytes"
+	"context"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/internal/clock"
+	"github.com/kopia/kopia/repo/blob"
+)
+
+type entry struct {
+	value          []byte
+	mtime          time.Time
+	retentionTime  time.Time
+	isDeleteMarker bool
+}
+
+type versionedEntries map[blob.ID][]*entry
+
+type versionedMapStorage struct {
+	data    versionedEntries
+	timeNow func() time.Time
+	mutex   sync.RWMutex
+}
+
+func (s *versionedMapStorage) getLatestByID(id blob.ID, writeIntent bool) (*entry, error) {
+	versions, ok := s.data[id]
+	if !ok {
+		return nil, blob.ErrBlobNotFound
+	}
+
+	// get the latest version and if it is a delete marker then simulate
+	// not-found
+	e := versions[len(versions)-1]
+	if e.isDeleteMarker {
+		return nil, blob.ErrBlobNotFound
+	}
+
+	if writeIntent && !e.retentionTime.IsZero() && e.retentionTime.After(s.timeNow()) {
+		return nil, errors.New("cannot alter object before retention period expires")
+	}
+
+	return e, nil
+}
+
+func (s *versionedMapStorage) GetBlob(ctx context.Context, id blob.ID, offset, length int64, output blob.OutputBuffer) error {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	e, err := s.getLatestByID(id, false)
+	if err != nil {
+		return blob.ErrBlobNotFound
+	}
+
+	output.Reset()
+
+	data := e.value
+
+	if length < 0 {
+		if _, err := output.Write(data); err != nil {
+			return errors.Wrap(err, "error writing data to output")
+		}
+
+		return nil
+	}
+
+	if int(offset) > len(data) || offset < 0 {
+		return errors.Wrapf(blob.ErrInvalidRange, "invalid offset: %v", offset)
+	}
+
+	data = data[offset:]
+	if int(length) > len(data) {
+		return errors.Wrapf(blob.ErrInvalidRange, "invalid length: %v", length)
+	}
+
+	if _, err := output.Write(data[0:length]); err != nil {
+		return errors.Wrap(err, "error writing data to output")
+	}
+
+	return nil
+}
+
+func (s *versionedMapStorage) GetMetadata(ctx context.Context, id blob.ID) (blob.Metadata, error) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	e, err := s.getLatestByID(id, false)
+	if err != nil {
+		return blob.Metadata{}, err
+	}
+
+	return blob.Metadata{
+		BlobID:    id,
+		Length:    int64(len(e.value)),
+		Timestamp: e.mtime,
+	}, nil
+}
+
+func (s *versionedMapStorage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes, opts blob.PutOptions) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	var b bytes.Buffer
+	if _, err := data.WriteTo(&b); err != nil {
+		return err
+	}
+
+	e := &entry{
+		value: b.Bytes(),
+		mtime: s.timeNow(),
+	}
+
+	if opts.HasRetentionOptions() {
+		e.retentionTime = e.mtime.Add(opts.RetentionPeriod)
+	}
+
+	s.data[id] = append(s.data[id], e)
+
+	return nil
+}
+
+func (s *versionedMapStorage) DeleteBlob(ctx context.Context, id blob.ID) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	// ths will prevent stacking (if latest is already a marker) or trailing
+	// (if entry does not exist) delete-markers
+	if _, err := s.getLatestByID(id, false); err != nil {
+		// no error if already deleted
+		if errors.Is(err, blob.ErrBlobNotFound) {
+			return nil
+		}
+
+		return err
+	}
+
+	s.data[id] = append(s.data[id], &entry{
+		mtime:          s.timeNow(),
+		isDeleteMarker: true,
+	})
+
+	return nil
+}
+
+func (s *versionedMapStorage) ListBlobs(ctx context.Context, prefix blob.ID, callback func(blob.Metadata) error) error {
+	s.mutex.RLock()
+
+	keys := []blob.ID{}
+
+	for k := range s.data {
+		if strings.HasPrefix(string(k), string(prefix)) {
+			keys = append(keys, k)
+		}
+	}
+
+	s.mutex.RUnlock()
+
+	sort.Slice(keys, func(i, j int) bool {
+		return keys[i] < keys[j]
+	})
+
+	for _, k := range keys {
+		m, err := s.GetMetadata(ctx, k)
+		if err != nil {
+			if errors.Is(err, blob.ErrBlobNotFound) {
+				continue
+			}
+
+			return err
+		}
+
+		if err := callback(m); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (s *versionedMapStorage) Close(ctx context.Context) error {
+	return nil
+}
+
+func (s *versionedMapStorage) SetTime(ctx context.Context, id blob.ID, t time.Time) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	e, err := s.getLatestByID(id, true)
+	if err != nil {
+		return err
+	}
+
+	e.mtime = t
+
+	return nil
+}
+
+func (s *versionedMapStorage) TouchBlob(ctx context.Context, id blob.ID, threshold time.Duration) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	e, err := s.getLatestByID(id, true)
+	if err != nil {
+		// no error if delete-marker or not-exists, prevent changing mtime
+		// of delete-markers
+		if errors.Is(err, blob.ErrBlobNotFound) {
+			return nil
+		}
+
+		return err
+	}
+
+	n := s.timeNow()
+	if n.Sub(e.mtime) >= threshold {
+		e.mtime = n
+	}
+
+	return nil
+}
+
+func (s *versionedMapStorage) ConnectionInfo() blob.ConnectionInfo {
+	// unsupported
+	return blob.ConnectionInfo{}
+}
+
+func (s *versionedMapStorage) DisplayName() string {
+	return "VersionedMap"
+}
+
+func (s *versionedMapStorage) FlushCaches(ctx context.Context) error {
+	return nil
+}
+
+// NewVersionedMapStorage returns an implementation of Storage backed by the
+// contents of an internal in-memory map used primarily for testing.
+func NewVersionedMapStorage(timeNow func() time.Time) blob.Storage {
+	if timeNow == nil {
+		timeNow = clock.Now
+	}
+
+	return &versionedMapStorage{data: make(versionedEntries), timeNow: timeNow}
+}

--- a/internal/blobtesting/versionedmap_test.go
+++ b/internal/blobtesting/versionedmap_test.go
@@ -1,0 +1,23 @@
+package blobtesting
+
+import (
+	"testing"
+	"time"
+
+	"github.com/minio/minio-go/v7"
+
+	"github.com/kopia/kopia/internal/testlogging"
+	"github.com/kopia/kopia/repo/blob"
+)
+
+func TestVersionedMapStorage(t *testing.T) {
+	r := NewVersionedMapStorage(nil)
+	if r == nil {
+		t.Errorf("unexpected result: %v", r)
+	}
+
+	VerifyStorage(testlogging.Context(t), t, r, blob.PutOptions{
+		RetentionMode:   minio.Governance.String(),
+		RetentionPeriod: 24 * time.Hour,
+	})
+}

--- a/internal/epoch/epoch_manager.go
+++ b/internal/epoch/epoch_manager.go
@@ -674,7 +674,7 @@ func (e *Manager) GetCompleteIndexSet(ctx context.Context, maxEpoch int) ([]blob
 }
 
 // WriteIndex writes new index blob by picking the appropriate prefix based on current epoch.
-func (e *Manager) WriteIndex(ctx context.Context, dataShards map[blob.ID]blob.Bytes) ([]blob.Metadata, error) {
+func (e *Manager) WriteIndex(ctx context.Context, dataShards map[blob.ID]blob.Bytes, retentionMode string, retentionPeriod time.Duration) ([]blob.Metadata, error) {
 	for {
 		cs, err := e.committedState(ctx)
 		if err != nil {
@@ -688,7 +688,7 @@ func (e *Manager) WriteIndex(ctx context.Context, dataShards map[blob.ID]blob.By
 		for unprefixedBlobID, data := range dataShards {
 			blobID := UncompactedEpochBlobPrefix(cs.WriteEpoch) + unprefixedBlobID
 
-			if err := e.st.PutBlob(ctx, blobID, data, blob.PutOptions{}); err != nil {
+			if err := e.st.PutBlob(ctx, blobID, data, blob.PutOptions{RetentionMode: retentionMode, RetentionPeriod: retentionPeriod}); err != nil {
 				return nil, errors.Wrap(err, "error writing index blob")
 			}
 

--- a/internal/epoch/epoch_manager_test.go
+++ b/internal/epoch/epoch_manager_test.go
@@ -103,7 +103,7 @@ func newTestEnv(t *testing.T) *epochManagerTestEnv {
 		EpochAdvanceOnCountThreshold:          15,
 		EpochAdvanceOnTotalSizeBytesThreshold: 20 << 20,
 		DeleteParallelism:                     1,
-	}, te.compact, testlogging.NewTestLogger(t), te.ft.NowFunc())
+	}, te.compact, testlogging.NewTestLogger(t), te.ft.NowFunc(), "", 0)
 	te.mgr = m
 	te.faultyStorage = fs
 	te.data = data
@@ -122,7 +122,7 @@ func (te *epochManagerTestEnv) another() *epochManagerTestEnv {
 		faultyStorage: te.faultyStorage,
 	}
 
-	te2.mgr = NewManager(te2.st, te.mgr.Params, te2.compact, te.mgr.log, te.mgr.timeFunc)
+	te2.mgr = NewManager(te2.st, te.mgr.Params, te2.compact, te.mgr.log, te.mgr.timeFunc, "", 0)
 
 	return te2
 }
@@ -177,7 +177,7 @@ func TestIndexEpochManager_Parallel(t *testing.T) {
 
 				if _, err := te2.mgr.WriteIndex(ctx, map[blob.ID]blob.Bytes{
 					blob.ID(fmt.Sprintf("w%vr%x", worker, rnd)): gather.FromSlice(ndx.Bytes()),
-				}, "", 0); err != nil {
+				}); err != nil {
 					return errors.Wrap(err, "error writing")
 				}
 
@@ -634,6 +634,6 @@ func (te *epochManagerTestEnv) mustWriteIndexFile(ctx context.Context, t *testin
 
 	_, err := te.mgr.WriteIndex(ctx, map[blob.ID]blob.Bytes{
 		blob.ID(hex.EncodeToString(rnd[:])): gather.FromSlice(ndx.Bytes()),
-	}, "", 0)
+	})
 	require.NoError(t, err)
 }

--- a/internal/epoch/epoch_manager_test.go
+++ b/internal/epoch/epoch_manager_test.go
@@ -177,7 +177,7 @@ func TestIndexEpochManager_Parallel(t *testing.T) {
 
 				if _, err := te2.mgr.WriteIndex(ctx, map[blob.ID]blob.Bytes{
 					blob.ID(fmt.Sprintf("w%vr%x", worker, rnd)): gather.FromSlice(ndx.Bytes()),
-				}); err != nil {
+				}, "", 0); err != nil {
 					return errors.Wrap(err, "error writing")
 				}
 
@@ -634,6 +634,6 @@ func (te *epochManagerTestEnv) mustWriteIndexFile(ctx context.Context, t *testin
 
 	_, err := te.mgr.WriteIndex(ctx, map[blob.ID]blob.Bytes{
 		blob.ID(hex.EncodeToString(rnd[:])): gather.FromSlice(ndx.Bytes()),
-	})
+	}, "", 0)
 	require.NoError(t, err)
 }

--- a/internal/repotesting/repotesting.go
+++ b/internal/repotesting/repotesting.go
@@ -70,7 +70,14 @@ func (e *Environment) setup(tb testing.TB, version content.FormatVersion, opts .
 		}
 	}
 
-	st := blobtesting.NewMapStorage(blobtesting.DataMap{}, nil, openOpt.TimeNowFunc)
+	var st blob.Storage
+	if opt.RetentionPeriod == 0 && opt.RetentionMode == "" {
+		st = blobtesting.NewMapStorage(blobtesting.DataMap{}, nil, openOpt.TimeNowFunc)
+	} else {
+		// use versioned mock storage when retention settings are specified
+		st = blobtesting.NewVersionedMapStorage(openOpt.TimeNowFunc)
+	}
+
 	st = newReconnectableStorage(tb, st)
 	e.st = st
 

--- a/repo/change_password.go
+++ b/repo/change_password.go
@@ -5,9 +5,10 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/pkg/errors"
+
 	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/repo/blob"
-	"github.com/pkg/errors"
 )
 
 // ChangePassword changes the repository password and rewrites
@@ -31,7 +32,7 @@ func (r *directRepository) ChangePassword(ctx context.Context, newPassword strin
 
 	r.formatEncryptionKey = newFormatEncryptionKey
 
-	if err := encryptFormatBytes(f, repoConfig, newFormatEncryptionKey, f.UniqueID); err != nil {
+	if err = encryptFormatBytes(f, repoConfig, newFormatEncryptionKey, f.UniqueID); err != nil {
 		return errors.Wrap(err, "unable to encrypt format bytes")
 	}
 
@@ -40,6 +41,7 @@ func (r *directRepository) ChangePassword(ctx context.Context, newPassword strin
 		return errors.Wrap(err, "unable to encrypt retention bytes")
 	}
 
+	// TODO: no need to put a blob when nil
 	if err := r.blobs.PutBlob(ctx, RetentionBlobID, gather.FromSlice(retentionBytes), blob.PutOptions{}); err != nil {
 		return errors.Wrap(err, "unable to write retention blob")
 	}

--- a/repo/change_password.go
+++ b/repo/change_password.go
@@ -56,8 +56,12 @@ func (r *directRepository) ChangePassword(ctx context.Context, newPassword strin
 
 	// remove cached kopia.repository blob.
 	if cd := r.cachingOptions.CacheDirectory; cd != "" {
-		if err := os.Remove(filepath.Join(r.cachingOptions.CacheDirectory, "kopia.repository")); err != nil {
-			log(ctx).Errorf("unable to remove kopia.repository: %v", err)
+		if err := os.Remove(filepath.Join(cd, FormatBlobID)); err != nil {
+			log(ctx).Errorf("unable to remove %s: %v", FormatBlobID, err)
+		}
+
+		if err := os.Remove(filepath.Join(cd, RetentionBlobID)); err != nil && !os.IsNotExist(err) {
+			log(ctx).Errorf("unable to remove %s: %v", RetentionBlobID, err)
 		}
 	}
 

--- a/repo/change_password.go
+++ b/repo/change_password.go
@@ -42,13 +42,15 @@ func (r *directRepository) ChangePassword(ctx context.Context, newPassword strin
 			return errors.Wrap(err, "unable to encrypt retention bytes")
 		}
 
-		// TODO: no need to put a blob when nil
-		if err := r.blobs.PutBlob(ctx, RetentionBlobID, gather.FromSlice(retentionBytes), blob.PutOptions{}); err != nil {
+		if err := r.blobs.PutBlob(ctx, RetentionBlobID, gather.FromSlice(retentionBytes), blob.PutOptions{
+			RetentionMode:   r.retentionBlob.Mode,
+			RetentionPeriod: r.retentionBlob.Period,
+		}); err != nil {
 			return errors.Wrap(err, "unable to write retention blob")
 		}
 	}
 
-	if err := writeFormatBlob(ctx, r.blobs, f); err != nil {
+	if err := writeFormatBlob(ctx, r.blobs, f, r.retentionBlob); err != nil {
 		return errors.Wrap(err, "unable to write format blob")
 	}
 

--- a/repo/change_password.go
+++ b/repo/change_password.go
@@ -36,14 +36,16 @@ func (r *directRepository) ChangePassword(ctx context.Context, newPassword strin
 		return errors.Wrap(err, "unable to encrypt format bytes")
 	}
 
-	retentionBytes, err := serializeRetentionBytes(f, r.retentionBlob, newFormatEncryptionKey)
-	if err != nil {
-		return errors.Wrap(err, "unable to encrypt retention bytes")
-	}
+	if !r.retentionBlob.IsNull() {
+		retentionBytes, err := serializeRetentionBytes(f, r.retentionBlob, newFormatEncryptionKey)
+		if err != nil {
+			return errors.Wrap(err, "unable to encrypt retention bytes")
+		}
 
-	// TODO: no need to put a blob when nil
-	if err := r.blobs.PutBlob(ctx, RetentionBlobID, gather.FromSlice(retentionBytes), blob.PutOptions{}); err != nil {
-		return errors.Wrap(err, "unable to write retention blob")
+		// TODO: no need to put a blob when nil
+		if err := r.blobs.PutBlob(ctx, RetentionBlobID, gather.FromSlice(retentionBytes), blob.PutOptions{}); err != nil {
+			return errors.Wrap(err, "unable to write retention blob")
+		}
 	}
 
 	if err := writeFormatBlob(ctx, r.blobs, f); err != nil {

--- a/repo/change_password.go
+++ b/repo/change_password.go
@@ -32,7 +32,7 @@ func (r *directRepository) ChangePassword(ctx context.Context, newPassword strin
 
 	r.formatEncryptionKey = newFormatEncryptionKey
 
-	if err = encryptFormatBytes(f, repoConfig, newFormatEncryptionKey, f.UniqueID); err != nil {
+	if err := encryptFormatBytes(f, repoConfig, newFormatEncryptionKey, f.UniqueID); err != nil {
 		return errors.Wrap(err, "unable to encrypt format bytes")
 	}
 

--- a/repo/content/committed_read_manager.go
+++ b/repo/content/committed_read_manager.go
@@ -97,6 +97,8 @@ type SharedManager struct {
 	repositoryFormatBytes   []byte
 	indexVersion            int
 	indexShardSize          int
+	retentionMode           string
+	retentionPeriod         time.Duration
 
 	// logger where logs should be written
 	log logging.Logger
@@ -414,13 +416,15 @@ func (sm *SharedManager) setupReadManagerCaches(ctx context.Context, caching *Ca
 
 	// set up new index blob manager
 	sm.indexBlobManagerV1 = &indexBlobManagerV1{
-		st:             cachedSt,
-		enc:            sm.enc,
-		timeNow:        sm.timeNow,
-		maxPackSize:    sm.maxPackSize,
-		indexShardSize: sm.indexShardSize,
-		indexVersion:   sm.indexVersion,
-		log:            sm.namedLogger("index-blob-manager"),
+		st:              cachedSt,
+		enc:             sm.enc,
+		timeNow:         sm.timeNow,
+		maxPackSize:     sm.maxPackSize,
+		indexShardSize:  sm.indexShardSize,
+		indexVersion:    sm.indexVersion,
+		log:             sm.namedLogger("index-blob-manager"),
+		retentionMode:   sm.retentionMode,
+		retentionPeriod: sm.retentionPeriod,
 	}
 	sm.indexBlobManagerV1.epochMgr = epoch.NewManager(cachedSt, sm.format.EpochParameters, sm.indexBlobManagerV1.compactEpoch, sm.namedLogger("epoch-manager"), sm.timeNow)
 
@@ -568,6 +572,8 @@ func NewSharedManager(ctx context.Context, st blob.Storage, f *FormattingOptions
 		internalLogManager:      ilm,
 		internalLogger:          internalLog,
 		contextLogger:           logging.Module(FormatLogModule)(ctx),
+		retentionMode:           opts.RetentionMode,
+		retentionPeriod:         opts.RetentionPeriod,
 	}
 
 	// remember logger defined for the context.

--- a/repo/content/content_manager.go
+++ b/repo/content/content_manager.go
@@ -819,6 +819,8 @@ type ManagerOptions struct {
 	RepositoryFormatBytes []byte
 	TimeNow               func() time.Time // Time provider
 	DisableInternalLog    bool
+	RetentionMode         string
+	RetentionPeriod       time.Duration
 }
 
 // CloneOrDefault returns a clone of provided ManagerOptions or default empty struct if nil.

--- a/repo/content/content_manager.go
+++ b/repo/content/content_manager.go
@@ -510,6 +510,11 @@ func (bm *WriteManager) ContentFormat() FormattingOptions {
 	return bm.format
 }
 
+// RetentionOptions returns formatting options.
+func (bm *WriteManager) RetentionOptions() RetentionOptions {
+	return RetentionOptions{Mode: bm.retentionMode, Period: bm.retentionPeriod}
+}
+
 // Close closes the content manager.
 func (bm *WriteManager) Close(ctx context.Context) error {
 	return bm.SharedManager.release(ctx)

--- a/repo/content/content_manager_lock_free.go
+++ b/repo/content/content_manager_lock_free.go
@@ -161,7 +161,10 @@ func (bm *WriteManager) writePackFileNotLocked(ctx context.Context, packFile blo
 	bm.Stats.wroteContent(data.Length())
 	bm.onUpload(int64(data.Length()))
 
-	return errors.Wrap(bm.st.PutBlob(ctx, packFile, data, blob.PutOptions{}), "error writing pack file")
+	return errors.Wrap(bm.st.PutBlob(ctx, packFile, data, blob.PutOptions{
+		RetentionMode:   bm.retentionMode,
+		RetentionPeriod: bm.retentionPeriod,
+	}), "error writing pack file")
 }
 
 func (sm *SharedManager) hashData(output []byte, data gather.Bytes) []byte {

--- a/repo/content/content_reader.go
+++ b/repo/content/content_reader.go
@@ -10,6 +10,7 @@ import (
 type Reader interface {
 	SupportsContentCompression() bool
 	ContentFormat() FormattingOptions
+	RetentionOptions() RetentionOptions
 	GetContent(ctx context.Context, id ID) ([]byte, error)
 	ContentInfo(ctx context.Context, id ID) (Info, error)
 	IterateContents(ctx context.Context, opts IterateOptions, callback IterateCallback) error

--- a/repo/content/index_blob_manager_v1.go
+++ b/repo/content/index_blob_manager_v1.go
@@ -15,14 +15,16 @@ import (
 )
 
 type indexBlobManagerV1 struct {
-	st             blob.Storage
-	enc            *encryptedBlobMgr
-	epochMgr       *epoch.Manager
-	timeNow        func() time.Time
-	log            logging.Logger
-	maxPackSize    int
-	indexVersion   int
-	indexShardSize int
+	st              blob.Storage
+	enc             *encryptedBlobMgr
+	epochMgr        *epoch.Manager
+	timeNow         func() time.Time
+	log             logging.Logger
+	maxPackSize     int
+	indexVersion    int
+	indexShardSize  int
+	retentionMode   string
+	retentionPeriod time.Duration
 }
 
 func (m *indexBlobManagerV1) listActiveIndexBlobs(ctx context.Context) ([]IndexBlobInfo, time.Time, error) {
@@ -95,7 +97,10 @@ func (m *indexBlobManagerV1) compactEpoch(ctx context.Context, blobIDs []blob.ID
 			return errors.Wrap(err, "error encrypting")
 		}
 
-		if err := m.st.PutBlob(ctx, blobID, data2.Bytes(), blob.PutOptions{}); err != nil {
+		if err := m.st.PutBlob(ctx, blobID, data2.Bytes(), blob.PutOptions{
+			RetentionMode:   m.retentionMode,
+			RetentionPeriod: m.retentionPeriod,
+		}); err != nil {
 			return errors.Wrap(err, "error writing index blob")
 		}
 	}

--- a/repo/content/index_blob_manager_v1.go
+++ b/repo/content/index_blob_manager_v1.go
@@ -127,7 +127,7 @@ func (m *indexBlobManagerV1) writeIndexBlobs(ctx context.Context, dataShards []g
 	}
 
 	// nolint:wrapcheck
-	return m.epochMgr.WriteIndex(ctx, shards)
+	return m.epochMgr.WriteIndex(ctx, shards, m.retentionMode, m.retentionPeriod)
 }
 
 var _ indexBlobManager = (*indexBlobManagerV1)(nil)

--- a/repo/format_block.go
+++ b/repo/format_block.go
@@ -33,6 +33,10 @@ var formatBlobChecksumSecret = []byte("kopia-repository")
 // FormatBlobID is the identifier of a BLOB that describes repository format.
 const FormatBlobID = "kopia.repository"
 
+// RetentionBlogID is the identifier of a BLOB that describes BLOB retention
+// settings for the repository.
+const RetentionBlobID = "kopia.retention"
+
 var (
 	purposeAESKey   = []byte("AES")
 	purposeAuthData = []byte("CHECKSUM")

--- a/repo/format_block.go
+++ b/repo/format_block.go
@@ -17,6 +17,7 @@ import (
 )
 
 const (
+	aes256GcmEncryption             = "AES256_GCM"
 	defaultFormatEncryption         = "AES256_GCM"
 	lengthOfRecoverBlockLength      = 2 // number of bytes used to store recover block length
 	maxChecksummedFormatBytesLength = 65000
@@ -33,7 +34,7 @@ var formatBlobChecksumSecret = []byte("kopia-repository")
 // FormatBlobID is the identifier of a BLOB that describes repository format.
 const FormatBlobID = "kopia.repository"
 
-// RetentionBlogID is the identifier of a BLOB that describes BLOB retention
+// RetentionBlobID is the identifier of a BLOB that describes BLOB retention
 // settings for the repository.
 const RetentionBlobID = "kopia.retention"
 
@@ -186,7 +187,7 @@ func (f *formatBlob) decryptFormatBytes(masterKey []byte) (*repositoryObjectForm
 	case "NONE": // do nothing
 		return f.UnencryptedFormat, nil
 
-	case "AES256_GCM":
+	case aes256GcmEncryption:
 		plainText, err := decryptRepositoryBlobBytesAes256Gcm(f.EncryptedFormatBytes, masterKey, f.UniqueID)
 		if err != nil {
 			return nil, errors.Errorf("unable to decrypt repository format")
@@ -271,11 +272,12 @@ func encryptFormatBytes(f *formatBlob, format *repositoryObjectFormat, masterKey
 		f.UnencryptedFormat = format
 		return nil
 
-	case "AES256_GCM":
+	case aes256GcmEncryption:
 		content, err := json.Marshal(&encryptedRepositoryConfig{Format: *format})
 		if err != nil {
 			return errors.Wrap(err, "can't marshal format to JSON")
 		}
+
 		content, err = encryptRepositoryBlobBytesAes256Gcm(content, masterKey, repositoryID)
 		if err != nil {
 			return errors.Wrap(err, "failed to encrypt format JSON")

--- a/repo/format_block.go
+++ b/repo/format_block.go
@@ -166,7 +166,7 @@ func verifyFormatBlobChecksum(b []byte) ([]byte, bool) {
 	return data, true
 }
 
-func writeFormatBlob(ctx context.Context, st blob.Storage, f *formatBlob) error {
+func writeFormatBlob(ctx context.Context, st blob.Storage, f *formatBlob, r *retentionBlob) error {
 	buf := gather.NewWriteBuffer()
 	e := json.NewEncoder(buf)
 	e.SetIndent("", "  ")
@@ -175,7 +175,10 @@ func writeFormatBlob(ctx context.Context, st blob.Storage, f *formatBlob) error 
 		return errors.Wrap(err, "unable to marshal format blob")
 	}
 
-	if err := st.PutBlob(ctx, FormatBlobID, buf.Bytes(), blob.PutOptions{}); err != nil {
+	if err := st.PutBlob(ctx, FormatBlobID, buf.Bytes(), blob.PutOptions{
+		RetentionMode:   r.Mode,
+		RetentionPeriod: r.Period,
+	}); err != nil {
 		return errors.Wrap(err, "unable to write format blob")
 	}
 

--- a/repo/format_block.go
+++ b/repo/format_block.go
@@ -187,22 +187,9 @@ func (f *formatBlob) decryptFormatBytes(masterKey []byte) (*repositoryObjectForm
 		return f.UnencryptedFormat, nil
 
 	case "AES256_GCM":
-		aead, authData, err := initCrypto(masterKey, f.UniqueID)
+		plainText, err := decryptRepositoryBlobBytesAes256Gcm(f.EncryptedFormatBytes, masterKey, f.UniqueID)
 		if err != nil {
-			return nil, errors.Wrap(err, "cannot initialize cipher")
-		}
-
-		content := append([]byte(nil), f.EncryptedFormatBytes...)
-		if len(content) < aead.NonceSize() {
-			return nil, errors.Errorf("invalid encrypted payload, too short")
-		}
-
-		nonce := content[0:aead.NonceSize()]
-		payload := content[aead.NonceSize():]
-
-		plainText, err := aead.Open(payload[:0], nonce, payload, authData)
-		if err != nil {
-			return nil, errors.Errorf("unable to decrypt repository format, invalid credentials?")
+			return nil, errors.Errorf("unable to decrypt repository format")
 		}
 
 		var erc encryptedRepositoryConfig
@@ -234,6 +221,50 @@ func initCrypto(masterKey, repositoryID []byte) (cipher.AEAD, []byte, error) {
 	return aead, authData, nil
 }
 
+func encryptRepositoryBlobBytesAes256Gcm(content, masterKey, repositoryID []byte) ([]byte, error) {
+	aead, authData, err := initCrypto(masterKey, repositoryID)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to initialize crypto")
+	}
+
+	nonceLength := aead.NonceSize()
+	noncePlusContentLength := nonceLength + len(content)
+	cipherText := make([]byte, noncePlusContentLength+aead.Overhead())
+
+	// Store nonce at the beginning of ciphertext.
+	nonce := cipherText[0:nonceLength]
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, errors.Wrap(err, "error reading random bytes for nonce")
+	}
+
+	b := aead.Seal(cipherText[nonceLength:nonceLength], nonce, content, authData)
+	content = nonce[0 : nonceLength+len(b)]
+
+	return content, nil
+}
+
+func decryptRepositoryBlobBytesAes256Gcm(content, masterKey, repositoryID []byte) ([]byte, error) {
+	aead, authData, err := initCrypto(masterKey, repositoryID)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot initialize cipher")
+	}
+
+	content = append([]byte(nil), content...)
+	if len(content) < aead.NonceSize() {
+		return nil, errors.Errorf("invalid encrypted payload, too short")
+	}
+
+	nonce := content[0:aead.NonceSize()]
+	payload := content[aead.NonceSize():]
+
+	plainText, err := aead.Open(payload[:0], nonce, payload, authData)
+	if err != nil {
+		return nil, errors.Errorf("unable to decrypt repository blob, invalid credentials?")
+	}
+
+	return plainText, nil
+}
+
 func encryptFormatBytes(f *formatBlob, format *repositoryObjectFormat, masterKey, repositoryID []byte) error {
 	switch f.EncryptionAlgorithm {
 	case "NONE":
@@ -245,24 +276,11 @@ func encryptFormatBytes(f *formatBlob, format *repositoryObjectFormat, masterKey
 		if err != nil {
 			return errors.Wrap(err, "can't marshal format to JSON")
 		}
-
-		aead, authData, err := initCrypto(masterKey, repositoryID)
+		content, err = encryptRepositoryBlobBytesAes256Gcm(content, masterKey, repositoryID)
 		if err != nil {
-			return errors.Wrap(err, "unable to initialize crypto")
+			return errors.Wrap(err, "failed to encrypt format JSON")
 		}
 
-		nonceLength := aead.NonceSize()
-		noncePlusContentLength := nonceLength + len(content)
-		cipherText := make([]byte, noncePlusContentLength+aead.Overhead())
-
-		// Store nonce at the beginning of ciphertext.
-		nonce := cipherText[0:nonceLength]
-		if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
-			return errors.Wrap(err, "error reading random bytes for nonce")
-		}
-
-		b := aead.Seal(cipherText[nonceLength:nonceLength], nonce, content, authData)
-		content = nonce[0 : nonceLength+len(b)]
 		f.EncryptedFormatBytes = content
 
 		return nil

--- a/repo/initialize.go
+++ b/repo/initialize.go
@@ -86,11 +86,11 @@ func Initialize(ctx context.Context, st blob.Storage, opt *NewRepositoryOptions,
 		return errors.Wrap(err, "invalid parameters")
 	}
 
-	if err := f.MutableParameters.Validate(); err != nil {
+	if err = f.MutableParameters.Validate(); err != nil {
 		return errors.Wrap(err, "invalid parameters")
 	}
 
-	if err := encryptFormatBytes(format, f, formatEncryptionKey, format.UniqueID); err != nil {
+	if err = encryptFormatBytes(format, f, formatEncryptionKey, format.UniqueID); err != nil {
 		return errors.Wrap(err, "unable to encrypt format bytes")
 	}
 

--- a/repo/initialize.go
+++ b/repo/initialize.go
@@ -94,7 +94,7 @@ func Initialize(ctx context.Context, st blob.Storage, opt *NewRepositoryOptions,
 		return errors.Wrap(err, "unable to encrypt format bytes")
 	}
 
-	retentionBytes, err := serializeRetentionBytes(format, retention, formatEncryptionKey, format.UniqueID)
+	retentionBytes, err := serializeRetentionBytes(format, retention, formatEncryptionKey)
 	if err != nil {
 		return errors.Wrap(err, "unable to encrypt retention bytes")
 	}

--- a/repo/initialize.go
+++ b/repo/initialize.go
@@ -94,15 +94,17 @@ func Initialize(ctx context.Context, st blob.Storage, opt *NewRepositoryOptions,
 		return errors.Wrap(err, "unable to encrypt format bytes")
 	}
 
-	retentionBytes, err := serializeRetentionBytes(format, retention, formatEncryptionKey)
-	if err != nil {
-		return errors.Wrap(err, "unable to encrypt retention bytes")
-	}
+	if !retention.IsNull() {
+		retentionBytes, err := serializeRetentionBytes(format, retention, formatEncryptionKey)
+		if err != nil {
+			return errors.Wrap(err, "unable to encrypt retention bytes")
+		}
 
-	// Write the retention blob first so that we'll consider the repository
-	// corrupted if writing the format blob fails later.
-	if err := st.PutBlob(ctx, RetentionBlobID, gather.FromSlice(retentionBytes), blob.PutOptions{}); err != nil {
-		return errors.Wrap(err, "unable to write retention blob")
+		// Write the retention blob first so that we'll consider the repository
+		// corrupted if writing the format blob fails later.
+		if err := st.PutBlob(ctx, RetentionBlobID, gather.FromSlice(retentionBytes), blob.PutOptions{}); err != nil {
+			return errors.Wrap(err, "unable to write retention blob")
+		}
 	}
 
 	if err := writeFormatBlob(ctx, st, format); err != nil {

--- a/repo/initialize.go
+++ b/repo/initialize.go
@@ -102,12 +102,15 @@ func Initialize(ctx context.Context, st blob.Storage, opt *NewRepositoryOptions,
 
 		// Write the retention blob first so that we'll consider the repository
 		// corrupted if writing the format blob fails later.
-		if err := st.PutBlob(ctx, RetentionBlobID, gather.FromSlice(retentionBytes), blob.PutOptions{}); err != nil {
+		if err := st.PutBlob(ctx, RetentionBlobID, gather.FromSlice(retentionBytes), blob.PutOptions{
+			RetentionMode:   retention.Mode,
+			RetentionPeriod: retention.Period,
+		}); err != nil {
 			return errors.Wrap(err, "unable to write retention blob")
 		}
 	}
 
-	if err := writeFormatBlob(ctx, st, format); err != nil {
+	if err := writeFormatBlob(ctx, st, format, retention); err != nil {
 		return errors.Wrap(err, "unable to write format blob")
 	}
 

--- a/repo/initialize.go
+++ b/repo/initialize.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"io"
 	"os"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -33,10 +34,12 @@ const (
 // NewRepositoryOptions specifies options that apply to newly created repositories.
 // All fields are optional, when not provided, reasonable defaults will be used.
 type NewRepositoryOptions struct {
-	UniqueID     []byte                    `json:"uniqueID"` // force the use of particular unique ID
-	BlockFormat  content.FormattingOptions `json:"blockFormat"`
-	DisableHMAC  bool                      `json:"disableHMAC"`
-	ObjectFormat object.Format             `json:"objectFormat"` // object format
+	UniqueID        []byte                    `json:"uniqueID"` // force the use of particular unique ID
+	BlockFormat     content.FormattingOptions `json:"blockFormat"`
+	DisableHMAC     bool                      `json:"disableHMAC"`
+	ObjectFormat    object.Format             `json:"objectFormat"` // object format
+	RetentionMode   string                    `json:"retentionMode,omitempty"`
+	RetentionPeriod time.Duration             `json:"retentionPeriod,omitempty"`
 }
 
 // ErrAlreadyInitialized indicates that repository has already been initialized.
@@ -61,7 +64,17 @@ func Initialize(ctx context.Context, st blob.Storage, opt *NewRepositoryOptions,
 		return errors.Wrap(err, "unexpected error when checking for format blob")
 	}
 
+	err = st.GetBlob(ctx, RetentionBlobID, 0, -1, &tmp)
+	if err == nil {
+		return ErrAlreadyInitialized
+	}
+
+	if !errors.Is(err, blob.ErrBlobNotFound) {
+		return errors.Wrap(err, "unexpected error when checking for retention blob")
+	}
+
 	format := formatBlobFromOptions(opt)
+	retention := retentionBlobFromOptions(opt)
 
 	formatEncryptionKey, err := format.deriveFormatEncryptionKeyFromPassword(password)
 	if err != nil {
@@ -79,6 +92,17 @@ func Initialize(ctx context.Context, st blob.Storage, opt *NewRepositoryOptions,
 
 	if err := encryptFormatBytes(format, f, formatEncryptionKey, format.UniqueID); err != nil {
 		return errors.Wrap(err, "unable to encrypt format bytes")
+	}
+
+	retentionBytes, err := serializeRetentionBytes(format, retention, formatEncryptionKey, format.UniqueID)
+	if err != nil {
+		return errors.Wrap(err, "unable to encrypt retention bytes")
+	}
+
+	// Write the retention blob first so that we'll consider the repository
+	// corrupted if writing the format blob fails later.
+	if err := st.PutBlob(ctx, RetentionBlobID, gather.FromSlice(retentionBytes), blob.PutOptions{}); err != nil {
+		return errors.Wrap(err, "unable to write retention blob")
 	}
 
 	if err := writeFormatBlob(ctx, st, format); err != nil {

--- a/repo/local_config.go
+++ b/repo/local_config.go
@@ -49,7 +49,7 @@ func (o ClientOptions) ApplyDefaults(ctx context.Context, defaultDesc string) Cl
 	}
 
 	if o.FormatBlobCacheDuration == 0 {
-		o.FormatBlobCacheDuration = defaultFormatBlobCacheDuration
+		o.FormatBlobCacheDuration = defaultRepositoryBlobCacheDuration
 	}
 
 	return o

--- a/repo/open.go
+++ b/repo/open.go
@@ -31,9 +31,9 @@ const CacheDirMarkerFile = "CACHEDIR.TAG"
 // CacheDirMarkerHeader is the header signature for cache dir marker files.
 const CacheDirMarkerHeader = "Signature: 8a477f597d28d172789f06886806bc55"
 
-// defaultFormatBlobCacheDuration is the duration for which we treat cached kopia.repository
+// defaultRepositoryBlobCacheDuration is the duration for which we treat cached kopia.repository
 // as valid.
-const defaultFormatBlobCacheDuration = 15 * time.Minute
+const defaultRepositoryBlobCacheDuration = 15 * time.Minute
 
 // throttlingWindow is the duration window during which the throttling token bucket fully replenishes.
 // the maximum number of tokens in the bucket is multiplied by the number of seconds.
@@ -352,7 +352,7 @@ func formatBytesCachingEnabled(cacheDirectory string, validDuration time.Duratio
 	return validDuration > 0
 }
 
-func readFormatBlobBytesFromCache(ctx context.Context, cachedFile string, validDuration time.Duration) ([]byte, error) {
+func readRepositoryBlobBytesFromCache(ctx context.Context, cachedFile string, validDuration time.Duration) ([]byte, error) {
 	cst, err := os.Stat(cachedFile)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to open cache file")
@@ -374,7 +374,7 @@ func readAndCacheRepositoryBlobBytes(ctx context.Context, st blob.Storage, cache
 	cachedFile := filepath.Join(cacheDirectory, blobID)
 
 	if validDuration == 0 {
-		validDuration = defaultFormatBlobCacheDuration
+		validDuration = defaultRepositoryBlobCacheDuration
 	}
 
 	if cacheDirectory != "" {
@@ -385,7 +385,7 @@ func readAndCacheRepositoryBlobBytes(ctx context.Context, st blob.Storage, cache
 
 	cacheEnabled := formatBytesCachingEnabled(cacheDirectory, validDuration)
 	if cacheEnabled {
-		b, err := readFormatBlobBytesFromCache(ctx, cachedFile, validDuration)
+		b, err := readRepositoryBlobBytesFromCache(ctx, cachedFile, validDuration)
 		if err == nil {
 			log(ctx).Debugf("%s retrieved from cache", blobID)
 

--- a/repo/open.go
+++ b/repo/open.go
@@ -281,6 +281,7 @@ func openWithConfig(ctx context.Context, st blob.Storage, lc *LocalConfig, passw
 			uniqueID:            f.UniqueID,
 			cachingOptions:      *caching,
 			formatBlob:          f,
+			retentionBlob:       retentionConfig,
 			formatEncryptionKey: formatEncryptionKey,
 			timeNow:             cmOpts.TimeNow,
 			cliOpts:             lc.ClientOptions.ApplyDefaults(ctx, "Repository in "+st.DisplayName()),

--- a/repo/open.go
+++ b/repo/open.go
@@ -422,7 +422,7 @@ func readAndCacheRepositoryBlobs(ctx context.Context, st blob.Storage, cacheDire
 
 	// Read retention blob, potentially from cache.
 	rb, err := readAndCacheRepositoryBlobBytes(ctx, st, cacheDirectory, RetentionBlobID, validDuration)
-	if err != nil {
+	if err != nil && !errors.Is(err, blob.ErrBlobNotFound) {
 		return nil, nil, errors.Wrap(err, "unable to read retention blob")
 	}
 

--- a/repo/parameters.go
+++ b/repo/parameters.go
@@ -29,7 +29,7 @@ func (r *directRepository) SetParameters(ctx context.Context, m content.MutableP
 		return errors.Errorf("unable to encrypt format bytes")
 	}
 
-	if err := writeFormatBlob(ctx, r.blobs, f); err != nil {
+	if err := writeFormatBlob(ctx, r.blobs, f, r.retentionBlob); err != nil {
 		return errors.Wrap(err, "unable to write format blob")
 	}
 

--- a/repo/repository.go
+++ b/repo/repository.go
@@ -88,6 +88,7 @@ type directRepositoryParameters struct {
 	cliOpts             ClientOptions
 	timeNow             func() time.Time
 	formatBlob          *formatBlob
+	retentionBlob       *retentionBlob
 	formatEncryptionKey []byte
 	nextWriterID        *int32
 }

--- a/repo/repository.go
+++ b/repo/repository.go
@@ -77,7 +77,7 @@ type DirectRepositoryWriter interface {
 
 	BlobStorage() blob.Storage
 	ContentManager() *content.WriteManager
-	SetParameters(ctx context.Context, m content.MutableParameters) error
+	SetParameters(ctx context.Context, m content.MutableParameters, ro content.RetentionOptions) error
 	ChangePassword(ctx context.Context, newPassword string) error
 }
 

--- a/repo/repository_test.go
+++ b/repo/repository_test.go
@@ -448,7 +448,8 @@ func TestObjectWritesWithRetention(t *testing.T) {
 		prefixesWithRetention = append(prefixesWithRetention, string(prefix))
 	}
 
-	prefixesWithRetention = append(prefixesWithRetention, content.IndexBlobPrefix, epoch.EpochManagerIndexUberPrefix)
+	prefixesWithRetention = append(prefixesWithRetention, content.IndexBlobPrefix, epoch.EpochManagerIndexUberPrefix,
+		repo.FormatBlobID, repo.RetentionBlobID)
 
 	// make sure that we cannot set mtime on the kopia objects created due to the
 	// retention time constraint

--- a/repo/repository_test.go
+++ b/repo/repository_test.go
@@ -396,10 +396,12 @@ func TestInitializeWithRetentionBlob(t *testing.T) {
 		NewRepositoryOptions: func(n *repo.NewRepositoryOptions) {
 			n.RetentionMode = minio.Governance.String()
 			n.RetentionPeriod = time.Hour * 24
-		}})
+		},
+	})
+
+	var d gather.WriteBuffer
 
 	// verify that the retention blob is created
-	var d gather.WriteBuffer
 	require.NoError(t, env.RepositoryWriter.BlobStorage().GetBlob(ctx, repo.RetentionBlobID, 0, -1, &d))
 	require.NoError(t, env.RepositoryWriter.ChangePassword(ctx, "new-password"))
 	// verify that the retention blob is created and is different after
@@ -412,7 +414,8 @@ func TestInitializeWithNoRetention(t *testing.T) {
 		NewRepositoryOptions: func(n *repo.NewRepositoryOptions) {
 			n.RetentionMode = minio.Governance.String()
 			n.RetentionPeriod = 0 // no-effect
-		}})
+		},
+	})
 
 	// verify that the retention blob is NOT created because the retention period is not
 	// specified
@@ -424,7 +427,8 @@ func TestObjectWritesWithRetention(t *testing.T) {
 		NewRepositoryOptions: func(n *repo.NewRepositoryOptions) {
 			n.RetentionMode = minio.Governance.String()
 			n.RetentionPeriod = time.Hour * 24
-		}})
+		},
+	})
 
 	writer := env.RepositoryWriter.NewObjectWriter(ctx, object.WriterOptions{})
 	_, err := writer.Write([]byte("the quick brown fox jumps over the lazy dog"))

--- a/repo/retention_blob.go
+++ b/repo/retention_blob.go
@@ -12,6 +12,10 @@ type retentionBlob struct {
 	Period time.Duration `json:"period,omitempty"`
 }
 
+func (r *retentionBlob) IsNull() bool {
+	return r.Mode == "" || r.Period == 0
+}
+
 func retentionBlobFromOptions(opt *NewRepositoryOptions) *retentionBlob {
 	return &retentionBlob{
 		Mode:   opt.RetentionMode,

--- a/repo/retention_blob.go
+++ b/repo/retention_blob.go
@@ -1,9 +1,7 @@
 package repo
 
 import (
-	"crypto/rand"
 	"encoding/json"
-	"io"
 	"time"
 
 	"github.com/pkg/errors"
@@ -21,79 +19,47 @@ func retentionBlobFromOptions(opt *NewRepositoryOptions) *retentionBlob {
 	}
 }
 
-// TODO: return a stream instead of []byte
 func serializeRetentionBytes(f *formatBlob, r *retentionBlob, masterKey, repositoryID []byte) ([]byte, error) {
 	content, err := json.Marshal(r)
 	if err != nil {
 		return nil, errors.Wrap(err, "can't marshal retentionBlob to JSON")
 	}
 
-	// TODO: generalize this with encryptFormatBytes()
 	switch f.EncryptionAlgorithm {
 	case "NONE":
 		return content, nil
 
 	case "AES256_GCM":
-		aead, authData, err := initCrypto(masterKey, repositoryID)
-		if err != nil {
-			return nil, errors.Wrap(err, "unable to initialize crypto")
-		}
-
-		nonceLength := aead.NonceSize()
-		noncePlusContentLength := nonceLength + len(content)
-		cipherText := make([]byte, noncePlusContentLength+aead.Overhead())
-
-		// Store nonce at the beginning of ciphertext.
-		nonce := cipherText[0:nonceLength]
-		if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
-			return nil, errors.Wrap(err, "error reading random bytes for nonce")
-		}
-
-		b := aead.Seal(cipherText[nonceLength:nonceLength], nonce, content, authData)
-		content = nonce[0 : nonceLength+len(b)]
-
-		return content, nil
+		return encryptRepositoryBlobBytesAes256Gcm(content, masterKey, repositoryID)
 
 	default:
 		return nil, errors.Errorf("unknown encryption algorithm: '%v'", f.EncryptionAlgorithm)
 	}
 }
 
-func deserializeRetentionBytes(f *formatBlob, encryptedRepositoryBytes []byte, masterKey []byte) (*retentionBlob, error) {
+func deserializeRetentionBytes(f *formatBlob, encryptedRetentionBytes []byte, masterKey []byte) (*retentionBlob, error) {
 	var (
 		plainText []byte
 		r         = &retentionBlob{}
+		err       error
 	)
 
 	switch f.EncryptionAlgorithm {
 	case "NONE": // do nothing
-		plainText = encryptedRepositoryBytes
+		plainText = encryptedRetentionBytes
 
 	case "AES256_GCM":
-		aead, authData, err := initCrypto(masterKey, f.UniqueID)
+		plainText, err = decryptRepositoryBlobBytesAes256Gcm(encryptedRetentionBytes, masterKey, f.UniqueID)
 		if err != nil {
-			return nil, errors.Wrap(err, "cannot initialize cipher")
-		}
-
-		content := append([]byte(nil), encryptedRepositoryBytes...)
-		if len(content) < aead.NonceSize() {
-			return nil, errors.Errorf("invalid encrypted payload, too short")
-		}
-
-		nonce := content[0:aead.NonceSize()]
-		payload := content[aead.NonceSize():]
-
-		plainText, err = aead.Open(payload[:0], nonce, payload, authData)
-		if err != nil {
-			return nil, errors.Errorf("unable to decrypt repository blob, invalid credentials?")
+			return nil, errors.Errorf("unable to decrypt repository retention blob")
 		}
 
 	default:
 		return nil, errors.Errorf("unknown encryption algorithm: '%v'", f.EncryptionAlgorithm)
 	}
 
-	if err := json.Unmarshal(plainText, &r); err != nil {
-		return nil, errors.Wrap(err, "invalid repository format")
+	if err = json.Unmarshal(plainText, &r); err != nil {
+		return nil, errors.Wrap(err, "invalid repository retention blob")
 	}
 
 	return r, nil

--- a/repo/retention_blob.go
+++ b/repo/retention_blob.go
@@ -19,7 +19,7 @@ func retentionBlobFromOptions(opt *NewRepositoryOptions) *retentionBlob {
 	}
 }
 
-func serializeRetentionBytes(f *formatBlob, r *retentionBlob, masterKey, repositoryID []byte) ([]byte, error) {
+func serializeRetentionBytes(f *formatBlob, r *retentionBlob, masterKey []byte) ([]byte, error) {
 	content, err := json.Marshal(r)
 	if err != nil {
 		return nil, errors.Wrap(err, "can't marshal retentionBlob to JSON")
@@ -30,7 +30,7 @@ func serializeRetentionBytes(f *formatBlob, r *retentionBlob, masterKey, reposit
 		return content, nil
 
 	case "AES256_GCM":
-		return encryptRepositoryBlobBytesAes256Gcm(content, masterKey, repositoryID)
+		return encryptRepositoryBlobBytesAes256Gcm(content, masterKey, f.UniqueID)
 
 	default:
 		return nil, errors.Errorf("unknown encryption algorithm: '%v'", f.EncryptionAlgorithm)

--- a/repo/retention_blob.go
+++ b/repo/retention_blob.go
@@ -1,0 +1,100 @@
+package repo
+
+import (
+	"crypto/rand"
+	"encoding/json"
+	"io"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+type retentionBlob struct {
+	Mode   string        `json:"mode,omitempty"`
+	Period time.Duration `json:"period,omitempty"`
+}
+
+func retentionBlobFromOptions(opt *NewRepositoryOptions) *retentionBlob {
+	return &retentionBlob{
+		Mode:   opt.RetentionMode,
+		Period: opt.RetentionPeriod,
+	}
+}
+
+// TODO: return a stream instead of []byte
+func serializeRetentionBytes(f *formatBlob, r *retentionBlob, masterKey, repositoryID []byte) ([]byte, error) {
+	content, err := json.Marshal(r)
+	if err != nil {
+		return nil, errors.Wrap(err, "can't marshal retentionBlob to JSON")
+	}
+
+	// TODO: generalize this with encryptFormatBytes()
+	switch f.EncryptionAlgorithm {
+	case "NONE":
+		return content, nil
+
+	case "AES256_GCM":
+		aead, authData, err := initCrypto(masterKey, repositoryID)
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to initialize crypto")
+		}
+
+		nonceLength := aead.NonceSize()
+		noncePlusContentLength := nonceLength + len(content)
+		cipherText := make([]byte, noncePlusContentLength+aead.Overhead())
+
+		// Store nonce at the beginning of ciphertext.
+		nonce := cipherText[0:nonceLength]
+		if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+			return nil, errors.Wrap(err, "error reading random bytes for nonce")
+		}
+
+		b := aead.Seal(cipherText[nonceLength:nonceLength], nonce, content, authData)
+		content = nonce[0 : nonceLength+len(b)]
+
+		return content, nil
+
+	default:
+		return nil, errors.Errorf("unknown encryption algorithm: '%v'", f.EncryptionAlgorithm)
+	}
+}
+
+func deserializeRetentionBytes(f *formatBlob, encryptedRepositoryBytes []byte, masterKey []byte) (*retentionBlob, error) {
+	var (
+		plainText []byte
+		r         = &retentionBlob{}
+	)
+
+	switch f.EncryptionAlgorithm {
+	case "NONE": // do nothing
+		plainText = encryptedRepositoryBytes
+
+	case "AES256_GCM":
+		aead, authData, err := initCrypto(masterKey, f.UniqueID)
+		if err != nil {
+			return nil, errors.Wrap(err, "cannot initialize cipher")
+		}
+
+		content := append([]byte(nil), encryptedRepositoryBytes...)
+		if len(content) < aead.NonceSize() {
+			return nil, errors.Errorf("invalid encrypted payload, too short")
+		}
+
+		nonce := content[0:aead.NonceSize()]
+		payload := content[aead.NonceSize():]
+
+		plainText, err = aead.Open(payload[:0], nonce, payload, authData)
+		if err != nil {
+			return nil, errors.Errorf("unable to decrypt repository blob, invalid credentials?")
+		}
+
+	default:
+		return nil, errors.Errorf("unknown encryption algorithm: '%v'", f.EncryptionAlgorithm)
+	}
+
+	if err := json.Unmarshal(plainText, &r); err != nil {
+		return nil, errors.Wrap(err, "invalid repository format")
+	}
+
+	return r, nil
+}

--- a/repo/retention_blob.go
+++ b/repo/retention_blob.go
@@ -29,7 +29,7 @@ func serializeRetentionBytes(f *formatBlob, r *retentionBlob, masterKey []byte) 
 	case "NONE":
 		return content, nil
 
-	case "AES256_GCM":
+	case aes256GcmEncryption:
 		return encryptRepositoryBlobBytesAes256Gcm(content, masterKey, f.UniqueID)
 
 	default:
@@ -37,7 +37,7 @@ func serializeRetentionBytes(f *formatBlob, r *retentionBlob, masterKey []byte) 
 	}
 }
 
-func deserializeRetentionBytes(f *formatBlob, encryptedRetentionBytes []byte, masterKey []byte) (*retentionBlob, error) {
+func deserializeRetentionBytes(f *formatBlob, encryptedRetentionBytes, masterKey []byte) (*retentionBlob, error) {
 	var (
 		plainText []byte
 		r         = &retentionBlob{}
@@ -48,7 +48,7 @@ func deserializeRetentionBytes(f *formatBlob, encryptedRetentionBytes []byte, ma
 	case "NONE": // do nothing
 		plainText = encryptedRetentionBytes
 
-	case "AES256_GCM":
+	case aes256GcmEncryption:
 		plainText, err = decryptRepositoryBlobBytesAes256Gcm(encryptedRetentionBytes, masterKey, f.UniqueID)
 		if err != nil {
 			return nil, errors.Errorf("unable to decrypt repository retention blob")

--- a/repo/retention_blob.go
+++ b/repo/retention_blob.go
@@ -48,6 +48,10 @@ func deserializeRetentionBytes(f *formatBlob, encryptedRetentionBytes, masterKey
 		err       error
 	)
 
+	if encryptedRetentionBytes == nil {
+		return r, nil
+	}
+
 	switch f.EncryptionAlgorithm {
 	case "NONE": // do nothing
 		plainText = encryptedRetentionBytes


### PR DESCRIPTION
This is a follow-up PR of https://github.com/kastenhq/kopia/pull/325 that introduces the retention blob and its specification at the time of repo creation. This PR adds the ability to update the retention parameters on an existing repository.