### PR TITLE
Kopia Repository Upgrade Lock

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -121,6 +121,7 @@ type App struct {
 	persistCredentials            bool
 	disableInternalLog            bool
 	AdvancedCommands              string
+	upgradeOwnerID                string
 
 	currentAction   string
 	onExitCallbacks []func()
@@ -230,6 +231,7 @@ func (c *App) setup(app *kingpin.Application) {
 	app.Flag("persist-credentials", "Persist credentials").Default("true").Envar("KOPIA_PERSIST_CREDENTIALS_ON_CONNECT").BoolVar(&c.persistCredentials)
 	app.Flag("disable-internal-log", "Disable internal log").Hidden().Envar("KOPIA_DISABLE_INTERNAL_LOG").BoolVar(&c.disableInternalLog)
 	app.Flag("advanced-commands", "Enable advanced (and potentially dangerous) commands.").Hidden().Envar("KOPIA_ADVANCED_COMMANDS").StringVar(&c.AdvancedCommands)
+	app.Flag("upgrade-owner-id", "Repository format upgrade owner-id.").Hidden().Envar("KOPIA_REPO_UPGRADE_OWNER_ID").StringVar(&c.upgradeOwnerID)
 
 	c.setupOSSpecificKeychainFlags(app)
 

--- a/cli/command_repository.go
+++ b/cli/command_repository.go
@@ -11,6 +11,7 @@ type commandRepository struct {
 	status           commandRepositoryStatus
 	syncTo           commandRepositorySyncTo
 	validateProvider commandRepositoryValidateProvider
+	upgrade          commandRepositoryUpgrade
 }
 
 func (c *commandRepository) setup(svc advancedAppServices, parent commandParent) {
@@ -26,4 +27,5 @@ func (c *commandRepository) setup(svc advancedAppServices, parent commandParent)
 	c.syncTo.setup(svc, cmd) // nolint:contextcheck
 	c.changePassword.setup(svc, cmd)
 	c.validateProvider.setup(svc, cmd)
+	c.upgrade.setup(svc, cmd)
 }

--- a/cli/command_repository_set_parameters.go
+++ b/cli/command_repository_set_parameters.go
@@ -6,15 +6,15 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/kopia/kopia/internal/epoch"
 	"github.com/kopia/kopia/internal/units"
 	"github.com/kopia/kopia/repo"
-	"github.com/kopia/kopia/repo/content"
 )
 
 type commandRepositorySetParameters struct {
-	maxPackSizeMB      int
-	indexFormatVersion int
+	maxPackSizeMB           int
+	indexFormatVersion      int
+	disableFormatBlobCache  bool
+	formatBlobCacheDuration time.Duration
 
 	epochRefreshFrequency    time.Duration
 	epochMinDuration         time.Duration
@@ -24,8 +24,6 @@ type commandRepositorySetParameters struct {
 	epochDeleteParallelism   int
 	epochCheckpointFrequency int
 
-	upgradeRepositoryFormat bool
-
 	svc appServices
 }
 
@@ -34,8 +32,8 @@ func (c *commandRepositorySetParameters) setup(svc appServices, parent commandPa
 
 	cmd.Flag("max-pack-size-mb", "Set max pack file size").PlaceHolder("MB").IntVar(&c.maxPackSizeMB)
 	cmd.Flag("index-version", "Set version of index format used for writing").IntVar(&c.indexFormatVersion)
-
-	cmd.Flag("upgrade", "Upgrade repository to the latest stable format").BoolVar(&c.upgradeRepositoryFormat)
+	cmd.Flag("repository-format-cache-duration", "Duration of kopia.repository format blob cache").Hidden().DurationVar(&c.formatBlobCacheDuration)
+	cmd.Flag("disable-repository-format-cache", "Disable caching of kopia.repository format blob").Hidden().BoolVar(&c.disableFormatBlobCache)
 
 	cmd.Flag("epoch-refresh-frequency", "Epoch refresh frequency").DurationVar(&c.epochRefreshFrequency)
 	cmd.Flag("epoch-min-duration", "Minimal duration of a single epoch").DurationVar(&c.epochMinDuration)
@@ -99,24 +97,9 @@ func (c *commandRepositorySetParameters) run(ctx context.Context, rep repo.Direc
 
 	mp := rep.ContentReader().ContentFormat().MutableParameters
 
-	upgradeToEpochManager := false
-
-	if c.upgradeRepositoryFormat {
-		anyChange = true
-
-		if !mp.EpochParameters.Enabled {
-			mp.EpochParameters = epoch.DefaultParameters
-			upgradeToEpochManager = true
-			mp.IndexVersion = 2
-		}
-
-		if mp.Version < content.FormatVersion2 {
-			mp.Version = content.FormatVersion2
-		}
-	}
-
 	c.setSizeMBParameter(ctx, c.maxPackSizeMB, "maximum pack size", &mp.MaxPackSize, &anyChange)
 	c.setIntParameter(ctx, c.indexFormatVersion, "index format version", &mp.IndexVersion, &anyChange)
+	c.setDurationParameter(ctx, c.formatBlobCacheDuration, repo.FormatBlobID+" format blob cache", &mp.FormatBlobCacheDuration, &anyChange)
 
 	c.setDurationParameter(ctx, c.epochMinDuration, "minimum epoch duration", &mp.EpochParameters.MinEpochDuration, &anyChange)
 	c.setDurationParameter(ctx, c.epochRefreshFrequency, "epoch refresh frequency", &mp.EpochParameters.EpochRefreshFrequency, &anyChange)
@@ -128,14 +111,6 @@ func (c *commandRepositorySetParameters) run(ctx context.Context, rep repo.Direc
 
 	if !anyChange {
 		return errors.Errorf("no changes")
-	}
-
-	if upgradeToEpochManager {
-		log(ctx).Infof("migrating current indexes to epoch format")
-
-		if err := rep.ContentManager().PrepareUpgradeToIndexBlobManagerV1(ctx, mp.EpochParameters); err != nil {
-			return errors.Wrap(err, "error upgrading indexes")
-		}
 	}
 
 	if err := rep.SetParameters(ctx, mp); err != nil {

--- a/cli/command_repository_set_parameters_test.go
+++ b/cli/command_repository_set_parameters_test.go
@@ -18,10 +18,13 @@ func (s *formatSpecificTestSuite) TestRepositorySetParameters(t *testing.T) {
 	// default values
 	require.Contains(t, out, "Max pack length:     20 MiB")
 
-	if s.formatVersion == content.FormatVersion1 {
+	switch s.formatVersion {
+	case content.FormatVersion1:
 		require.Contains(t, out, "Format version:      1")
-	} else {
+	case content.FormatVersion2:
 		require.Contains(t, out, "Format version:      2")
+	default:
+		require.Contains(t, out, "Format version:      3")
 	}
 
 	// failure cases
@@ -48,17 +51,35 @@ func (s *formatSpecificTestSuite) TestRepositorySetParametersUpgrade(t *testing.
 	// default values
 	require.Contains(t, out, "Max pack length:     20 MiB")
 
-	if s.formatVersion == content.FormatVersion1 {
+	switch s.formatVersion {
+	case content.FormatVersion1:
 		require.Contains(t, out, "Format version:      1")
 		require.Contains(t, out, "Epoch Manager:       disabled")
 		env.RunAndExpectFailure(t, "index", "epoch", "list")
-	} else {
+	case content.FormatVersion2:
 		require.Contains(t, out, "Format version:      2")
+		require.Contains(t, out, "Epoch Manager:       enabled")
+		env.RunAndExpectSuccess(t, "index", "epoch", "list")
+	default:
+		require.Contains(t, out, "Format version:      3")
 		require.Contains(t, out, "Epoch Manager:       enabled")
 		env.RunAndExpectSuccess(t, "index", "epoch", "list")
 	}
 
-	env.RunAndExpectSuccess(t, "repository", "set-parameters", "--upgrade")
+	if s.formatVersion < content.FormatVersion3 {
+		env.RunAndExpectSuccess(t, "repository", "upgrade",
+			"--upgrade-owner-id", "owner",
+			"--io-drain-timeout", "1s",
+			"--status-poll-interval", "1s",
+			"--max-clock-drift", "1s")
+	} else {
+		env.RunAndExpectFailure(t, "repository", "upgrade",
+			"--upgrade-owner-id", "owner",
+			"--io-drain-timeout", "1s",
+			"--status-poll-interval", "1s",
+			"--max-clock-drift", "1s")
+	}
+
 	env.RunAndExpectSuccess(t, "repository", "set-parameters", "--epoch-min-duration", "3h")
 	env.RunAndExpectSuccess(t, "repository", "set-parameters", "--epoch-cleanup-safety-margin", "23h")
 	env.RunAndExpectSuccess(t, "repository", "set-parameters", "--epoch-advance-on-size-mb", "77")
@@ -74,7 +95,7 @@ func (s *formatSpecificTestSuite) TestRepositorySetParametersUpgrade(t *testing.
 	out = env.RunAndExpectSuccess(t, "repository", "status")
 	require.Contains(t, out, "Epoch Manager:       enabled")
 	require.Contains(t, out, "Index Format:        v2")
-	require.Contains(t, out, "Format version:      2")
+	require.Contains(t, out, "Format version:      3")
 	require.Contains(t, out, "Epoch cleanup margin:    23h0m0s")
 	require.Contains(t, out, "Epoch advance on:        22 blobs or 77 MiB, minimum 3h0m0s")
 	require.Contains(t, out, "Epoch checkpoint every:  9 epochs")

--- a/cli/command_repository_status.go
+++ b/cli/command_repository_status.go
@@ -32,6 +32,33 @@ func (c *commandRepositoryStatus) setup(svc advancedAppServices, parent commandP
 	c.out.setup(svc)
 }
 
+func (c *commandRepositoryStatus) dumpUpgradeStatus(dr repo.DirectRepository) {
+	cf := dr.ContentReader().ContentFormat()
+	if cf.UpgradeLock == nil {
+		return
+	}
+
+	locked, drainedClients := cf.UpgradeLock.IsLocked(dr.Time())
+	upgradeTime := cf.UpgradeLock.UpgradeTime()
+
+	c.out.printStdout("\n")
+	c.out.printStdout("Ongoing upgrade:     Format Version %d -> %d\n", cf.UpgradeLock.OldFormatVersion,
+		cf.MutableParameters.Version)
+	c.out.printStdout("Upgrade Time:        %s\n", upgradeTime.Local())
+
+	if locked {
+		c.out.printStdout("Upgrade lock:        Locked\n")
+	} else {
+		c.out.printStdout("Upgrade lock:        Unlocked\n")
+	}
+
+	if drainedClients {
+		c.out.printStdout("Lock status:         Fully Established\n")
+	} else {
+		c.out.printStdout("Lock status:         Draining\n")
+	}
+}
+
 func (c *commandRepositoryStatus) run(ctx context.Context, rep repo.Repository) error {
 	c.out.printStdout("Config file:         %v\n", c.svc.repositoryConfigFileName())
 	c.out.printStdout("\n")
@@ -40,14 +67,22 @@ func (c *commandRepositoryStatus) run(ctx context.Context, rep repo.Repository) 
 	c.out.printStdout("Username:            %v\n", rep.ClientOptions().Username)
 	c.out.printStdout("Read-only:           %v\n", rep.ClientOptions().ReadOnly)
 
-	if t := rep.ClientOptions().FormatBlobCacheDuration; t > 0 {
+	dr, isDr := rep.(repo.DirectRepository)
+	t := rep.ClientOptions().FormatBlobCacheDuration
+
+	if isDr {
+		if mpCacheInterval := dr.ContentReader().ContentFormat().MutableParameters.FormatBlobCacheDuration; mpCacheInterval != 0 {
+			t = mpCacheInterval
+		}
+	}
+
+	if t > 0 {
 		c.out.printStdout("Format blob cache:   %v\n", t)
 	} else {
 		c.out.printStdout("Format blob cache:   disabled\n")
 	}
 
-	dr, ok := rep.(repo.DirectRepository)
-	if !ok {
+	if !isDr {
 		return nil
 	}
 
@@ -89,6 +124,8 @@ func (c *commandRepositoryStatus) run(ctx context.Context, rep repo.Repository) 
 	} else {
 		c.out.printStdout("Epoch Manager:       disabled\n")
 	}
+
+	c.dumpUpgradeStatus(dr)
 
 	if !c.statusReconnectToken {
 		return nil

--- a/cli/command_repository_upgrade.go
+++ b/cli/command_repository_upgrade.go
@@ -1,0 +1,232 @@
+package cli
+
+import (
+	"context"
+	"path/filepath"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/internal/epoch"
+	"github.com/kopia/kopia/repo"
+	"github.com/kopia/kopia/repo/content"
+)
+
+type commandRepositoryUpgrade struct {
+	forceRollback   bool
+	skip            bool
+	blockUntilDrain bool
+
+	// lock settings
+	advanceNoticeInterval  time.Duration
+	ioDrainTimeout         time.Duration
+	statusPollInterval     time.Duration
+	maxPermittedClockDrift time.Duration
+
+	svc advancedAppServices
+}
+
+func (c *commandRepositoryUpgrade) setup(svc advancedAppServices, parent commandParent) {
+	cmd := parent.Command("upgrade", "Upgrade repository format.")
+
+	// TODO:
+	// cmd.GetFlag("upgrade-owner-id").Required()
+	// cmd.("owner-id", "The upgrade lock unique owner ID").Required().StringVar(&c.ownerId)
+
+	cmd.Flag("advance-notice", "Advance notice for upgrade to allow enough time for other Kopia clients to notice the lock").DurationVar(&c.advanceNoticeInterval)
+	cmd.Flag("io-drain-timeout", "Max time it should take all other Kopia clients to drop repository connections").Default(repo.DefaultFormatBlobCacheDuration.String()).DurationVar(&c.ioDrainTimeout)
+	cmd.Flag("status-poll-interval", "An advisory polling interval to check for the status of upgrade").Default("60s").DurationVar(&c.statusPollInterval)
+	cmd.Flag("max-clock-drift", "Maximum tolerated drift on clocks between all Kopia clients").Default("5m").DurationVar(&c.maxPermittedClockDrift)
+	cmd.Flag("block-until-drain", "Drain all the clients but do not perform the upgrade").BoolVar(&c.blockUntilDrain)
+
+	// TODO(small): make rollback a sub-command instead of a flag
+	cmd.Flag("force-rollback", "Force rollback the repository upgrade, this action can cause repository corruption").BoolVar(&c.forceRollback)
+
+	// upgrade sequence
+	cmd.Action(svc.directRepositoryWriteAction(c.runPhase(c.setLockIntent)))
+	cmd.Action(svc.directRepositoryWriteAction(c.runPhase(c.drainOrCommit)))
+	cmd.Action(svc.directRepositoryWriteAction(c.runPhase(c.upgrade)))
+	cmd.Action(svc.directRepositoryWriteAction(c.runPhase(c.commitUpgrade)))
+
+	c.svc = svc
+}
+
+func (c *commandRepositoryUpgrade) runPhase(act func(context.Context, repo.DirectRepositoryWriter) error) func(context.Context, repo.DirectRepositoryWriter) error {
+	return func(ctx context.Context, rep repo.DirectRepositoryWriter) error {
+		if !c.skip {
+			if err := act(ctx, rep); err != nil {
+				// exc=plicitly skip all stages on error because tests do not
+				// skip/exit on error because they override os.Exit()
+				c.skip = true
+				return err
+			}
+		}
+
+		return nil
+	}
+}
+
+func (c *commandRepositoryUpgrade) setLockIntent(ctx context.Context, rep repo.DirectRepositoryWriter) error {
+	if c.forceRollback {
+		if err := rep.RollbackUpgrade(ctx); err != nil {
+			return errors.Wrap(err, "failed to rollback the upgrade")
+		}
+
+		c.skip = true
+
+		return nil
+	}
+
+	now := rep.Time()
+	mp := rep.ContentReader().ContentFormat().MutableParameters
+	openOpts := c.svc.optionsFromFlags(ctx)
+	l := content.NewUpgradeLock(now, openOpts.UpgradeOwnerID, c.advanceNoticeInterval, c.ioDrainTimeout,
+		c.statusPollInterval, c.maxPermittedClockDrift, mp.Version)
+
+	// Update format-blob and clear the cache.
+	// This will fail if we have alread upgraded.
+	l, err := rep.SetUpgradeLockIntent(ctx, *l)
+	if err != nil {
+		return errors.Wrap(err, "error setting the upgrade lock intent")
+	}
+	// we need to reopen the repository after this point
+
+	locked, _ := l.IsLocked(now)
+	if l.AdvanceNoticeDuration != 0 && !locked && !c.blockUntilDrain {
+		upgradeTime := l.UpgradeTime()
+		log(ctx).Infof("Repository upgrade advance notice has been set, you must come back and perform the upgrade at %s.",
+			upgradeTime)
+
+		c.skip = true
+
+		return nil
+	}
+
+	log(ctx).Infof("Repository upgrade lock intent has been placed.")
+
+	return nil
+}
+
+func (c *commandRepositoryUpgrade) drainOrCommit(ctx context.Context, rep repo.DirectRepositoryWriter) error {
+	// skip next phases if requested
+	if c.blockUntilDrain {
+		c.skip = true
+	}
+
+	cf := rep.ContentReader().ContentFormat()
+	if cf.MutableParameters.EpochParameters.Enabled {
+		log(ctx).Infof("Repository indices have already been migrated to the epoch format, no need to drain other clients")
+
+		if cf.UpgradeLock.AdvanceNoticeDuration == 0 || !c.blockUntilDrain {
+			// let the upgrade continue to commit the new format blob
+			return nil
+		}
+
+		log(ctx).Infof("Continuing to drain since advance notice has been set and we have been requested to block until then")
+	}
+
+	if err := c.drainAllClients(ctx, rep); err != nil {
+		return errors.Wrap(err, "failed to upgrade the repository, lock is not released")
+	}
+	// we need to reopen the repository after this point
+
+	log(ctx).Infof("Successfully drained all repository clients, the lock has been fully-established now.")
+
+	return nil
+}
+
+// TODO(small): Better reuse.
+func sleepWithContext(ctx context.Context, dur time.Duration) {
+	t := time.NewTimer(dur)
+	defer t.Stop()
+
+	select {
+	case <-ctx.Done():
+	case <-t.C:
+	}
+}
+
+func (c *commandRepositoryUpgrade) drainAllClients(ctx context.Context, rep repo.DirectRepositoryWriter) error {
+	password, err := c.svc.getPasswordFromFlags(ctx, false, false)
+	if err != nil {
+		return errors.Wrap(err, "getting password")
+	}
+
+	configFile, err := filepath.Abs(c.svc.repositoryConfigFileName())
+	if err != nil {
+		return errors.Wrap(err, "error resolving config file path")
+	}
+
+	lc, err := repo.LoadConfigFromFile(configFile)
+	if err != nil {
+		return errors.Wrapf(err, "error loading config file %q", configFile)
+	}
+
+	cacheOpts := lc.Caching.CloneOrDefault()
+
+	for {
+		_, repoConfig, err := repo.ReadAndCacheRepoConfig(ctx, rep.BlobStorage(), password, cacheOpts, -1)
+		if err != nil {
+			return errors.Wrap(err, "Unable to reload the repository format blob.")
+		}
+
+		l := repoConfig.FormattingOptions.UpgradeLock
+		upgradeTime := l.UpgradeTime()
+		now := rep.Time()
+
+		log(ctx).Infof("Waiting for %s to allow all other kopia clients to drain ...", upgradeTime.Sub(rep.Time()).Round(time.Second))
+
+		locked, writersDrained := l.IsLocked(now)
+		if locked {
+			if writersDrained {
+				// we have the lock now
+				break
+			}
+		} else if !c.blockUntilDrain {
+			return errors.Wrap(err, "upgrade lock got revoked after the intent was placed, giving up.")
+		}
+
+		// TODO: this can get stuck
+		sleepWithContext(ctx, l.StatusPollInterval)
+	}
+
+	return nil
+}
+
+func (c *commandRepositoryUpgrade) upgrade(ctx context.Context, rep repo.DirectRepositoryWriter) error {
+	mp := rep.ContentReader().ContentFormat().MutableParameters
+	if mp.EpochParameters.Enabled {
+		// nothing to upgrade on format, so let the next action commit the upgraded format blob
+		return nil
+	}
+
+	mp.EpochParameters = epoch.DefaultParameters
+	mp.IndexVersion = 2
+
+	log(ctx).Infof("migrating current indices to epoch format")
+
+	if err := rep.ContentManager().PrepareUpgradeToIndexBlobManagerV1(ctx, mp.EpochParameters); err != nil {
+		return errors.Wrap(err, "error upgrading indices")
+	}
+
+	// update format-blob and clear the cache
+	if err := rep.SetParameters(ctx, mp); err != nil {
+		return errors.Wrap(err, "error setting parameters")
+	}
+	// we need to reopen the repository after this point
+
+	log(ctx).Infof("Repository indices have been upgraded.")
+
+	return nil
+}
+
+func (c *commandRepositoryUpgrade) commitUpgrade(ctx context.Context, rep repo.DirectRepositoryWriter) error {
+	if err := rep.CommitUpgrade(ctx); err != nil {
+		return errors.Wrap(err, "error finalizing upgrade")
+	}
+	// we need to reopen the repository after this point
+
+	log(ctx).Infof("Repository has been successfully upgraded.")
+
+	return nil
+}

--- a/cli/command_repository_upgrade_test.go
+++ b/cli/command_repository_upgrade_test.go
@@ -1,0 +1,205 @@
+package cli_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/repo/content"
+	"github.com/kopia/kopia/tests/testenv"
+)
+
+func (s *formatSpecificTestSuite) TestRepositoryUpgrade(t *testing.T) {
+	env := testenv.NewCLITest(t, s.formatFlags, testenv.NewInProcRunner(t))
+
+	env.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", env.RepoDir)
+	out := env.RunAndExpectSuccess(t, "repository", "status")
+
+	switch s.formatVersion {
+	case content.FormatVersion1:
+		require.Contains(t, out, "Format version:      1")
+		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
+			"--upgrade-owner-id", "owner",
+			"--io-drain-timeout", "1s",
+			"--status-poll-interval", "1s",
+			"--max-clock-drift", "1s")
+		require.Contains(t, stderr, "Repository indices have been upgraded.")
+		require.Contains(t, stderr, "Repository has been successfully upgraded.")
+	case content.FormatVersion2:
+		require.Contains(t, out, "Format version:      2")
+		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
+			"--upgrade-owner-id", "owner",
+			"--io-drain-timeout", "1s",
+			"--status-poll-interval", "1s",
+			"--max-clock-drift", "1s")
+		require.Contains(t, stderr, "Repository indices have already been migrated to the epoch format, no need to drain other clients")
+		require.Contains(t, stderr, "Repository has been successfully upgraded.")
+	default:
+		require.Contains(t, out, "Format version:      3")
+		env.RunAndExpectFailure(t, "repository", "upgrade",
+			"--upgrade-owner-id", "owner",
+			"--io-drain-timeout", "1s",
+			"--status-poll-interval", "1s",
+			"--max-clock-drift", "1s")
+	}
+
+	out = env.RunAndExpectSuccess(t, "repository", "status")
+	require.Contains(t, out, "Epoch Manager:       enabled")
+	require.Contains(t, out, "Index Format:        v2")
+	require.Contains(t, out, "Format version:      3")
+}
+
+// TODO(small): add a test to verify that 0.8 client will choke on version-3
+// TODO(small): add tests for set-parameters format-cache duration changes
+
+func (s *formatSpecificTestSuite) TestRepositoryUpgradeAdvanceNotice(t *testing.T) {
+	env := testenv.NewCLITest(t, s.formatFlags, testenv.NewInProcRunner(t))
+
+	env.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", env.RepoDir)
+	out := env.RunAndExpectSuccess(t, "repository", "status")
+
+	switch s.formatVersion {
+	case content.FormatVersion1:
+		require.Contains(t, out, "Format version:      1")
+		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
+			"--upgrade-owner-id", "owner",
+			"--io-drain-timeout", "1s",
+			"--status-poll-interval", "1s",
+			"--max-clock-drift", "1s",
+			"--advance-notice", "30s")
+		require.Contains(t, strings.Join(stderr, "\n"),
+			"Repository upgrade advance notice has been set, you must come back and perform the upgrade")
+
+		// verify that non-owner clients will fail to connect/upgrade
+		env.RunAndExpectFailure(t, "repository", "upgrade",
+			"--upgrade-owner-id", "non-owner",
+			"--io-drain-timeout", "1s",
+			"--status-poll-interval", "1s",
+			"--max-clock-drift", "1s")
+
+		// until we drain, we would be able to see the upgrade status
+		out = env.RunAndExpectSuccess(t, "repository", "status")
+		require.Contains(t, out, "Ongoing upgrade:     Format Version 1 -> 3")
+		require.Contains(t, out, "Upgrade lock:        Unlocked")
+		require.Contains(t, out, "Lock status:         Draining")
+
+		// attempt to rollback the upgrade and restart
+		env.RunAndExpectSuccess(t, "repository", "upgrade", "--force-rollback")
+		env.RunAndExpectSuccess(t, "repository", "upgrade",
+			"--upgrade-owner-id", "owner",
+			"--io-drain-timeout", "1s",
+			"--status-poll-interval", "1s",
+			"--max-clock-drift", "1s",
+			"--advance-notice", "30s")
+
+		// drain all clients
+		_, stderr = env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
+			"--block-until-drain",
+			"--upgrade-owner-id", "owner",
+			"--io-drain-timeout", "1s",
+			"--status-poll-interval", "1s",
+			"--max-clock-drift", "1s",
+			"--advance-notice", "30s")
+		require.Contains(t, stderr, "Successfully drained all repository clients, the lock has been fully-established now.")
+
+		// verify that access is denied after we drain
+		env.RunAndExpectFailure(t, "repository", "status")
+
+		// verify that owner clients can check status
+		out = env.RunAndExpectSuccess(t, "repository", "status", "--upgrade-owner-id", "owner")
+		require.Contains(t, out, "Ongoing upgrade:     Format Version 1 -> 3")
+		require.Contains(t, out, "Upgrade lock:        Locked")
+		require.Contains(t, out, "Lock status:         Fully Established")
+
+		// finalize the upgrade
+		_, stderr = env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
+			"--upgrade-owner-id", "owner",
+			"--io-drain-timeout", "1s",
+			"--status-poll-interval", "1s",
+			"--max-clock-drift", "1s",
+			"--advance-notice", "30s")
+		require.Contains(t, stderr, "Repository has been successfully upgraded.")
+
+		// verify that non-owner clients can resume access
+		env.RunAndExpectSuccess(t, "repository", "status")
+	case content.FormatVersion2:
+		require.Contains(t, out, "Format version:      2")
+		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
+			"--upgrade-owner-id", "owner",
+			"--io-drain-timeout", "1s",
+			"--status-poll-interval", "1s",
+			"--max-clock-drift", "1s",
+			"--advance-notice", "30s")
+		require.Contains(t, strings.Join(stderr, "\n"),
+			"Repository upgrade advance notice has been set, you must come back and perform the upgrade")
+
+		// verify that non-owner clients will fail to connect/upgrade
+		env.RunAndExpectFailure(t, "repository", "upgrade",
+			"--upgrade-owner-id", "non-owner",
+			"--io-drain-timeout", "1s",
+			"--status-poll-interval", "1s",
+			"--max-clock-drift", "1s")
+
+		// until we drain, we would be able to see the upgrade status
+		out = env.RunAndExpectSuccess(t, "repository", "status")
+		require.Contains(t, out, "Ongoing upgrade:     Format Version 2 -> 3")
+		require.Contains(t, out, "Upgrade lock:        Unlocked")
+		require.Contains(t, out, "Lock status:         Draining")
+
+		// attempt to rollback the upgrade and restart
+		env.RunAndExpectSuccess(t, "repository", "upgrade", "--force-rollback")
+		env.RunAndExpectSuccess(t, "repository", "upgrade",
+			"--upgrade-owner-id", "owner",
+			"--io-drain-timeout", "1s",
+			"--status-poll-interval", "1s",
+			"--max-clock-drift", "1s",
+			"--advance-notice", "30s")
+
+		// drain all clients
+		_, stderr = env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
+			"--block-until-drain",
+			"--upgrade-owner-id", "owner",
+			"--io-drain-timeout", "1s",
+			"--status-poll-interval", "1s",
+			"--max-clock-drift", "1s",
+			"--advance-notice", "30s")
+		require.Contains(t, stderr, "Repository indices have already been migrated to the epoch format, no need to drain other clients")
+		require.Contains(t, stderr, "Continuing to drain since advance notice has been set and we have been requested to block until then")
+		require.Contains(t, stderr, "Successfully drained all repository clients, the lock has been fully-established now.")
+
+		// verify that access is denied after we drain
+		env.RunAndExpectFailure(t, "repository", "status")
+
+		// verify that owner clients can check status
+		out = env.RunAndExpectSuccess(t, "repository", "status", "--upgrade-owner-id", "owner")
+		require.Contains(t, out, "Ongoing upgrade:     Format Version 2 -> 3")
+		require.Contains(t, out, "Upgrade lock:        Locked")
+		require.Contains(t, out, "Lock status:         Fully Established")
+
+		// finalize the upgrade
+		_, stderr = env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
+			"--upgrade-owner-id", "owner",
+			"--io-drain-timeout", "1s",
+			"--status-poll-interval", "1s",
+			"--max-clock-drift", "1s",
+			"--advance-notice", "30s")
+		require.Contains(t, stderr, "Repository has been successfully upgraded.")
+
+		// verify that non-owner clients can resume access
+		env.RunAndExpectSuccess(t, "repository", "status")
+	default:
+		require.Contains(t, out, "Format version:      3")
+		env.RunAndExpectFailure(t, "repository", "upgrade",
+			"--upgrade-owner-id", "owner",
+			"--io-drain-timeout", "1s",
+			"--status-poll-interval", "1s",
+			"--max-clock-drift", "1s",
+			"--advance-notice", "30s")
+	}
+
+	out = env.RunAndExpectSuccess(t, "repository", "status")
+	require.Contains(t, out, "Epoch Manager:       enabled")
+	require.Contains(t, out, "Index Format:        v2")
+	require.Contains(t, out, "Format version:      3")
+}

--- a/cli/config.go
+++ b/cli/config.go
@@ -63,6 +63,7 @@ func (c *App) optionsFromFlags(ctx context.Context) *repo.Options {
 	return &repo.Options{
 		TraceStorage:       c.traceStorage,
 		DisableInternalLog: c.disableInternalLog,
+		UpgradeOwnerID:     c.upgradeOwnerID,
 	}
 }
 

--- a/cli/suite_test.go
+++ b/cli/suite_test.go
@@ -19,3 +19,7 @@ func TestFormatV1(t *testing.T) {
 func TestFormatV2(t *testing.T) {
 	testutil.RunAllTestsWithParam(t, &formatSpecificTestSuite{[]string{"--format-version=2"}, content.FormatVersion2})
 }
+
+func TestFormatV3(t *testing.T) {
+	testutil.RunAllTestsWithParam(t, &formatSpecificTestSuite{[]string{"--format-version=3"}, content.FormatVersion3})
+}

--- a/internal/repotesting/repotesting.go
+++ b/internal/repotesting/repotesting.go
@@ -232,7 +232,7 @@ func repoOptions(openOpts []func(*repo.Options)) *repo.Options {
 }
 
 // FormatNotImportant chooses arbitrary format version where it's not important to the test.
-const FormatNotImportant = content.FormatVersion2
+const FormatNotImportant = content.FormatVersion3
 
 // NewEnvironment creates a new repository testing environment and ensures its cleanup at the end of the test.
 func NewEnvironment(tb testing.TB, version content.FormatVersion, opts ...Options) (context.Context, *Environment) {

--- a/repo/blob/beforeop/beforeop.go
+++ b/repo/blob/beforeop/beforeop.go
@@ -1,0 +1,53 @@
+// Package beforeop implements wrapper around blob.Storage that run a given callback before all operations.
+package beforeop
+
+import (
+	"context"
+
+	"github.com/kopia/kopia/repo/blob"
+)
+
+type callback func() error
+
+type beforeOp struct {
+	blob.Storage
+	cb callback
+}
+
+func (s beforeOp) GetBlob(ctx context.Context, id blob.ID, offset, length int64, output blob.OutputBuffer) error {
+	if err := s.cb(); err != nil {
+		return err
+	}
+
+	return s.Storage.GetBlob(ctx, id, offset, length, output) // nolint:wrapcheck
+}
+
+func (s beforeOp) GetMetadata(ctx context.Context, id blob.ID) (blob.Metadata, error) {
+	if err := s.cb(); err != nil {
+		return blob.Metadata{}, err
+	}
+
+	return s.Storage.GetMetadata(ctx, id) // nolint:wrapcheck
+}
+
+func (s beforeOp) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes, opts blob.PutOptions) error {
+	if err := s.cb(); err != nil {
+		return err
+	}
+
+	return s.Storage.PutBlob(ctx, id, data, opts) // nolint:wrapcheck
+}
+
+func (s beforeOp) DeleteBlob(ctx context.Context, id blob.ID) error {
+	if err := s.cb(); err != nil {
+		return err
+	}
+
+	return s.Storage.DeleteBlob(ctx, id) // nolint:wrapcheck
+}
+
+// NewWrapper creates a wrapped storage interface for data operations that need
+// to run a callback before the actual operation.
+func NewWrapper(wrapped blob.Storage, cb callback) blob.Storage {
+	return &beforeOp{Storage: wrapped, cb: cb}
+}

--- a/repo/blob/retrying/retrying_storage.go
+++ b/repo/blob/retrying/retrying_storage.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/kopia/kopia/internal/retry"
+	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/blob"
 )
 
@@ -69,6 +70,10 @@ func isRetriable(err error) bool {
 		return false
 
 	case errors.Is(err, blob.ErrSetTimeUnsupported):
+		return false
+
+	case errors.Is(err, repo.ErrRepositoryUnavailableDueToUpgrageInProgress):
+		// hard-fail when upgrade is in progress
 		return false
 
 	default:

--- a/repo/content/content_manager.go
+++ b/repo/content/content_manager.go
@@ -56,13 +56,13 @@ const (
 	defaultMaxPreambleLength = 32
 	defaultPaddingUnit       = 4096
 
-	currentWriteVersion = FormatVersion2
+	currentWriteVersion = FormatVersion3
 
 	minSupportedWriteVersion = FormatVersion1
-	maxSupportedWriteVersion = FormatVersion2
+	maxSupportedWriteVersion = FormatVersion3
 
 	minSupportedReadVersion = FormatVersion1
-	maxSupportedReadVersion = FormatVersion2
+	maxSupportedReadVersion = FormatVersion3
 
 	indexLoadAttempts = 10
 )

--- a/repo/content/content_upgrade_lock.go
+++ b/repo/content/content_upgrade_lock.go
@@ -1,0 +1,166 @@
+package content
+
+import (
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// UpgradeLock represents the intent to lock a kopia repository for upgrade
+// related maintenance activity. This signals a request for exclusive access to
+// the repository. The lock object is set on the Kopia repository format blob
+// 'kopia.repository' and must be respected by all clients accessing the
+// repository.
+type UpgradeLock struct {
+	OwnerID                string        `json:"ownerID,omitempty"`
+	CreationTime           time.Time     `json:"creationTime,omitempty"`
+	AdvanceNoticeDuration  time.Duration `json:"advanceNoticeDuration,omitempty"`
+	IODrainTimeout         time.Duration `json:"ioDrainTimeout,omitempty"`
+	StatusPollInterval     time.Duration `json:"statusPollInterval,omitempty"`
+	OldFormatVersion       FormatVersion `json:"oldFormatVersion,omitempty"`
+	MaxPermittedClockDrift time.Duration `json:"maxPermittedClockDrift,omitempty"`
+}
+
+// NewUpgradeLock constructs a new lock object for repository format upgrades.
+func NewUpgradeLock(
+	now time.Time,
+	ownerID string,
+	advanceNotice, ioDrainTimeout, statusPollInterval, maxPermittedClockDrift time.Duration,
+	oldFormatVersion FormatVersion,
+) *UpgradeLock {
+	return &UpgradeLock{
+		OwnerID:                ownerID,
+		CreationTime:           now,
+		AdvanceNoticeDuration:  advanceNotice,
+		IODrainTimeout:         ioDrainTimeout,
+		StatusPollInterval:     statusPollInterval,
+		MaxPermittedClockDrift: maxPermittedClockDrift,
+		OldFormatVersion:       oldFormatVersion,
+	}
+}
+
+// Update upgrades an existing lock intent. This method controls what mutations
+// are allowed on an upgrade lock once it has been placed on the repository.
+func (l *UpgradeLock) Update(other *UpgradeLock) (*UpgradeLock, error) {
+	if l.OwnerID != other.OwnerID {
+		// TODO: add tests for this
+		return nil, errors.Errorf("upgrade owner-id mismatch %q != %q, you are not the owner of the upgrade lock",
+			other.OwnerID, l.OwnerID)
+	}
+
+	switch {
+	case l.AdvanceNoticeDuration == 0:
+		if other.AdvanceNoticeDuration != 0 {
+			// TODO: add tests for this
+			return nil, errors.New("cannot set an advance notice an on existing lock")
+		}
+	case other.AdvanceNoticeDuration == 0:
+		// TODO: see if we can do this
+		// TODO: add tests for this
+		return nil, errors.New("cannot unset advance notice an on existing lock")
+	case other.UpgradeTime().Before(l.UpgradeTime()):
+		// TODO: see if we can jump backwards as well
+		// TODO: add tests for this
+		return nil, errors.New("can only extend the upgrade-time on an existing lock")
+	}
+
+	newL := l.Clone()
+	// currently the only allowed update is the notice time
+	newL.AdvanceNoticeDuration = other.AdvanceNoticeDuration
+
+	return newL, nil
+}
+
+// Clone creates a copy of the UpgradeLock instance.
+func (l *UpgradeLock) Clone() *UpgradeLock {
+	clone := *l
+	return &clone
+}
+
+// Validate verifies the parameters of an upgrade lock.
+func (l *UpgradeLock) Validate() error {
+	if l.OwnerID == "" {
+		return errors.New("no owner-id set, it is required to set a unique owner-id")
+	}
+
+	if l.CreationTime.IsZero() {
+		return errors.New("upgrade lock intent creation time is not set")
+	}
+
+	if l.IODrainTimeout <= 0 {
+		return errors.New("io-drain-timeout is required to be set for the upgrade lock")
+	}
+
+	if l.StatusPollInterval > l.IODrainTimeout {
+		return errors.New("status-poll-interval must be less than the io-drain-timeout")
+	}
+
+	if l.OldFormatVersion <= 0 {
+		return errors.New("old-format-version is not set")
+	}
+
+	if l.MaxPermittedClockDrift <= 0 {
+		return errors.New("max-permitted-clock-drift is not set")
+	}
+
+	if l.AdvanceNoticeDuration != 0 {
+		if l.AdvanceNoticeDuration < 0 {
+			// TODO: add tests for this
+			return errors.Errorf("the advanced notice duration %s cannot be negative", l.AdvanceNoticeDuration)
+		}
+
+		totalDrainInterval := l.totalDrainInterval()
+		if l.AdvanceNoticeDuration <= totalDrainInterval {
+			// TODO: add tests for this
+			return errors.Errorf("the advanced notice duration %s must be more than the total drain interval %s",
+				l.AdvanceNoticeDuration, totalDrainInterval)
+		}
+	}
+
+	return nil
+}
+
+// UpgradeTime returns the absolute time in future by when the upgrade lock
+// will be fully established, i.e. all non-upgrading-owner kopia accessors
+// would be drained.
+func (l *UpgradeLock) UpgradeTime() time.Time {
+	if l == nil {
+		return time.Time{}
+	}
+
+	var (
+		upgradeTime        time.Time
+		totalDrainInterval = l.totalDrainInterval()
+	)
+
+	if l.AdvanceNoticeDuration > totalDrainInterval {
+		upgradeTime = l.CreationTime.Add(l.AdvanceNoticeDuration)
+	} else {
+		upgradeTime = l.CreationTime.Add(totalDrainInterval)
+	}
+
+	return upgradeTime
+}
+
+func (l *UpgradeLock) totalDrainInterval() time.Duration {
+	return l.MaxPermittedClockDrift + 2*l.IODrainTimeout
+}
+
+// IsLocked indicates whether a lock intent has been placed and whether all
+// other repository accessors have been drained.
+func (l *UpgradeLock) IsLocked(now time.Time) (locked, writersDrained bool) {
+	if l == nil {
+		return false, false
+	}
+
+	totalDrainInterval := l.totalDrainInterval()
+	locked = l.AdvanceNoticeDuration < totalDrainInterval /* insufficient or no advance notice means immediate lock */ ||
+		!now.Before(l.CreationTime.Add(l.AdvanceNoticeDuration-totalDrainInterval)) // are we approaching the notice window ?
+	writersDrained = !now.Before(l.UpgradeTime())
+
+	if writersDrained && !locked {
+		panic("writers have drained but we are not locked, this is not possible until the upgrade-lock intent is invalid")
+	}
+
+	return locked, writersDrained
+}

--- a/repo/initialize.go
+++ b/repo/initialize.go
@@ -107,8 +107,10 @@ func repositoryObjectFormatFromOptions(opt *NewRepositoryOptions) (*repositoryOb
 			fv = content.FormatVersion1
 		case "2":
 			fv = content.FormatVersion2
+		case "3":
+			fv = content.FormatVersion3
 		default:
-			fv = content.FormatVersion2
+			fv = content.FormatVersion3
 		}
 	}
 

--- a/repo/local_config.go
+++ b/repo/local_config.go
@@ -49,7 +49,7 @@ func (o ClientOptions) ApplyDefaults(ctx context.Context, defaultDesc string) Cl
 	}
 
 	if o.FormatBlobCacheDuration == 0 {
-		o.FormatBlobCacheDuration = defaultFormatBlobCacheDuration
+		o.FormatBlobCacheDuration = DefaultFormatBlobCacheDuration
 	}
 
 	return o

--- a/repo/maintenance/suite_test.go
+++ b/repo/maintenance/suite_test.go
@@ -18,3 +18,7 @@ func TestFormatV1(t *testing.T) {
 func TestFormatV2(t *testing.T) {
 	testutil.RunAllTestsWithParam(t, &formatSpecificTestSuite{content.FormatVersion2})
 }
+
+func TestFormatV3(t *testing.T) {
+	testutil.RunAllTestsWithParam(t, &formatSpecificTestSuite{content.FormatVersion3})
+}

--- a/repo/repository.go
+++ b/repo/repository.go
@@ -79,6 +79,10 @@ type DirectRepositoryWriter interface {
 	ContentManager() *content.WriteManager
 	SetParameters(ctx context.Context, m content.MutableParameters) error
 	ChangePassword(ctx context.Context, newPassword string) error
+
+	SetUpgradeLockIntent(ctx context.Context, l content.UpgradeLock) (*content.UpgradeLock, error)
+	CommitUpgrade(ctx context.Context) error
+	RollbackUpgrade(ctx context.Context) error
 }
 
 type directRepositoryParameters struct {

--- a/repo/suite_test.go
+++ b/repo/suite_test.go
@@ -20,3 +20,7 @@ func TestFormatV1(t *testing.T) {
 func TestFormatV2(t *testing.T) {
 	testutil.RunAllTestsWithParam(t, &formatSpecificTestSuite{content.FormatVersion2})
 }
+
+func TestFormatV3(t *testing.T) {
+	testutil.RunAllTestsWithParam(t, &formatSpecificTestSuite{content.FormatVersion3})
+}

--- a/repo/upgrade_lock.go
+++ b/repo/upgrade_lock.go
@@ -1,0 +1,123 @@
+package repo
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/repo/content"
+)
+
+func (r *directRepository) updateRepoConfig(ctx context.Context, cb func(repoConfig *repositoryObjectFormat) error) (*repositoryObjectFormat, error) {
+	f := r.formatBlob
+
+	repoConfig, err := f.decryptFormatBytes(r.formatEncryptionKey)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to decrypt repository config")
+	}
+
+	if err := cb(repoConfig); err != nil {
+		return nil, err
+	}
+
+	if err := encryptFormatBytes(f, repoConfig, r.formatEncryptionKey, f.UniqueID); err != nil {
+		return nil, errors.Errorf("unable to encrypt format bytes")
+	}
+
+	if err := writeFormatBlob(ctx, r.blobs, f); err != nil {
+		return nil, errors.Wrap(err, "unable to write format blob")
+	}
+
+	if cd := r.cachingOptions.CacheDirectory; cd != "" {
+		if err := os.Remove(filepath.Join(cd, FormatBlobID)); err != nil && !os.IsNotExist(err) {
+			return nil, errors.Errorf("unable to remove cached repository format blob: %v", err)
+		}
+	}
+
+	return repoConfig, nil
+}
+
+// SetUpgradeLockIntent sets the upgrade lock intent on the repository format
+// blob for other clients to notice. If a lock intent was already placed then
+// it updates the existing lock using the output of the UpgradeLock.Update().
+//
+// This method also backs up the original format version on the upgrade lock
+// intent and sets the latest format-version o nthe repository blob. This
+// should cause the unsupporting clients (non-upgrade capable) to fail
+// connecting to the repository.
+func (r *directRepository) SetUpgradeLockIntent(ctx context.Context, l content.UpgradeLock) (*content.UpgradeLock, error) {
+	repoConfig, err := r.updateRepoConfig(ctx, func(repoConfig *repositoryObjectFormat) error {
+		if err := l.Validate(); err != nil {
+			return errors.Wrap(err, "invalid upgrade lock intent")
+		}
+
+		if repoConfig.FormattingOptions.UpgradeLock == nil {
+			// when we are putting a new lock then ensure that we can upgrade
+			// to that version
+			if repoConfig.FormattingOptions.Version >= content.FormatVersion3 {
+				return errors.Errorf("repository is already upgraded to %d, we can only upgrade till %d",
+					repoConfig.FormattingOptions.Version, content.FormatVersion3)
+			}
+			// backup the old format version
+			l.OldFormatVersion = repoConfig.FormattingOptions.Version
+			// set a new lock or revoke an existing lock
+			repoConfig.FormattingOptions.UpgradeLock = &l
+			// mark the upgrade to the new format version, this will ensure that older
+			// clients won't be able to parse the new version
+			repoConfig.FormattingOptions.Version = content.FormatVersion3
+		} else if newL, err := repoConfig.FormattingOptions.UpgradeLock.Update(&l); err == nil {
+			repoConfig.FormattingOptions.UpgradeLock = newL
+		} else {
+			return errors.Wrap(err, "failed to update the existing lock")
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return repoConfig.UpgradeLock, nil
+}
+
+// CommitUpgrade removes the upgrade lock from the from the repository format
+// blob. This in-effect commits the new repository format t othe repository and
+// resumes all access to the repository.
+func (r *directRepository) CommitUpgrade(ctx context.Context) error {
+	_, err := r.updateRepoConfig(ctx, func(repoConfig *repositoryObjectFormat) error {
+		if repoConfig.FormattingOptions.UpgradeLock == nil {
+			return errors.New("no upgrade in progress")
+		}
+
+		// restore the old format version
+		repoConfig.FormattingOptions.UpgradeLock = nil
+
+		return nil
+	})
+
+	return err
+}
+
+// RollbackUpgrade removes the upgrade lock while also restoring the
+// format-blob's original version. This method does not restore the original
+// repository data format and neither does it validate against any repository
+// changes. Rolling back the repository format is currently not supported and
+// hence using this API could render the repository corrupted and unreadable by
+// clients.
+func (r *directRepository) RollbackUpgrade(ctx context.Context) error {
+	_, err := r.updateRepoConfig(ctx, func(repoConfig *repositoryObjectFormat) error {
+		if repoConfig.FormattingOptions.UpgradeLock == nil {
+			return errors.New("no upgrade in progress")
+		}
+
+		// restore the old format version
+		repoConfig.FormattingOptions.Version = repoConfig.UpgradeLock.OldFormatVersion
+		repoConfig.FormattingOptions.UpgradeLock = nil
+
+		return nil
+	})
+
+	return err
+}

--- a/repo/upgrade_lock_test.go
+++ b/repo/upgrade_lock_test.go
@@ -1,0 +1,58 @@
+package repo_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/internal/repotesting"
+	"github.com/kopia/kopia/repo"
+	"github.com/kopia/kopia/repo/content"
+)
+
+func TestFormatUpgradeDuringOngoingWriteSessions(t *testing.T) {
+	ctx, env := repotesting.NewEnvironment(t, content.FormatVersion1)
+
+	rep := env.Repository // read-only
+
+	lw := rep.(repo.RepositoryWriter)
+
+	// w1, w2, w3 are indepdendent sessions.
+	_, w1, err := rep.NewWriter(ctx, repo.WriteSessionOptions{Purpose: "writer1"})
+	require.NoError(t, err)
+
+	defer w1.Close(ctx)
+
+	_, w2, err := rep.NewWriter(ctx, repo.WriteSessionOptions{Purpose: "writer2"})
+	require.NoError(t, err)
+
+	defer w2.Close(ctx)
+
+	_, w3, err := rep.NewWriter(ctx, repo.WriteSessionOptions{Purpose: "writer3"})
+	require.NoError(t, err)
+
+	defer w3.Close(ctx)
+
+	o1Data := []byte{1, 2, 3}
+	o2Data := []byte{2, 3, 4}
+	o3Data := []byte{3, 4, 5}
+	o4Data := []byte{4, 5, 6}
+
+	writeObject(ctx, t, w1, o1Data, "o1")
+	writeObject(ctx, t, w2, o2Data, "o2")
+	writeObject(ctx, t, w3, o3Data, "o3")
+	writeObject(ctx, t, lw, o4Data, "o4")
+
+	l := content.NewUpgradeLock(env.Repository.Time(), "upgrade-owner", 0, repo.DefaultFormatBlobCacheDuration,
+		repo.DefaultFormatBlobCacheDuration/2, repo.DefaultFormatBlobCacheDuration/3,
+		env.RepositoryWriter.ContentManager().ContentFormat().MutableParameters.Version)
+
+	_, err = env.RepositoryWriter.SetUpgradeLockIntent(ctx, *l)
+	require.NoError(t, err)
+
+	// ongoing writes should get interrupted
+	require.ErrorIs(t, w1.Flush(ctx), repo.ErrRepositoryUnavailableDueToUpgrageInProgress)
+	require.ErrorIs(t, w2.Flush(ctx), repo.ErrRepositoryUnavailableDueToUpgrageInProgress)
+	require.ErrorIs(t, w3.Flush(ctx), repo.ErrRepositoryUnavailableDueToUpgrageInProgress)
+	require.ErrorIs(t, lw.Flush(ctx), repo.ErrRepositoryUnavailableDueToUpgrageInProgress)
+}

--- a/site/content/docs/Upgrade/_index.md
+++ b/site/content/docs/Upgrade/_index.md
@@ -40,13 +40,15 @@ $ kopia repository disconnect
 
 * make sure to stop any running `kopia server` instances and disable all background kopia tasks, such as periodic snapshots in `crontab`.
 
-3. Upgrade all kopia clients to the latest version >=v0.9.x
+3. Upgrade all kopia clients to the latest version >=v0.10.x
 
 4. Using the designated `kopia` client, run:
 
 ```
-$ kopia repository set-parameters --upgrade
+$ kopia repository upgrade --upgrade-owner-id <unique-id>
 ```
+
+- TODO: update this doc to set notice and various override options (extend notice and force rollback)
 
 5. Verify upgrade by:
 
@@ -54,7 +56,7 @@ $ kopia repository set-parameters --upgrade
 $ kopia repository status
 ```
 
-You should see `Format version:      2`
+You should see `Format version:      3`
 
 5. Reconnect kopia clients that were disconnected in step 2 and re-enable all disabled background jobs.
 

--- a/snapshot/snapshotmaintenance/suite_test.go
+++ b/snapshot/snapshotmaintenance/suite_test.go
@@ -18,3 +18,7 @@ func TestFormatV1(t *testing.T) {
 func TestFormatV2(t *testing.T) {
 	testutil.RunAllTestsWithParam(t, &formatSpecificTestSuite{content.FormatVersion2})
 }
+
+func TestFormatV3(t *testing.T) {
+	testutil.RunAllTestsWithParam(t, &formatSpecificTestSuite{content.FormatVersion3})
+}

--- a/tests/compat_test/compat_test.go
+++ b/tests/compat_test/compat_test.go
@@ -33,7 +33,11 @@ func TestRepoCreatedWith08CanBeOpenedWithCurrent(t *testing.T) {
 	e2.RunAndExpectSuccess(t, "snap", "ls")
 
 	// upgrade
-	e2.RunAndExpectSuccess(t, "repo", "set-parameters", "--upgrade")
+	e2.RunAndExpectSuccess(t, "repository", "upgrade",
+		"--upgrade-owner-id", "owner",
+		"--io-drain-timeout", "1s",
+		"--status-poll-interval", "1s",
+		"--max-clock-drift", "1s")
 
 	// now 0.8 can't open it anymore
 	e3 := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner08)

--- a/tests/end_to_end_test/suite_test.go
+++ b/tests/end_to_end_test/suite_test.go
@@ -19,3 +19,7 @@ func TestFormatV1(t *testing.T) {
 func TestFormatV2(t *testing.T) {
 	testutil.RunAllTestsWithParam(t, &formatSpecificTestSuite{[]string{"--format-version=2"}, content.FormatVersion2})
 }
+
+func TestFormatV3(t *testing.T) {
+	testutil.RunAllTestsWithParam(t, &formatSpecificTestSuite{[]string{"--format-version=2"}, content.FormatVersion3})
+}


### PR DESCRIPTION
https://docs.google.com/document/d/1zIghQc4i4vJSANjSDBOvjzMiqnZSEp1cCasxSUkltSk/edit#heading=h.khston2oxmxy

Upgrading from format 1 to 3:
```sh
$ kopia repository upgrade --password 12345678 --config-file /tmp/kopia/repository.config --upgrade-owner-id owner --io-drain-timeout 1s --status-poll-interval 1s --max-clock-drift 1s
Repository upgrade lock intent has been placed.
Waiting for 2s to allow all other kopia clients to drain ...
Waiting for 1s to allow all other kopia clients to drain ...
Waiting for 0s to allow all other kopia clients to drain ...
Successfully drained all repository clients, the lock has been fully-established now.
migrating current indexes to epoch format
Repository indices have been upgraded.
Repository has been successfully upgraded
```

Upgrading from format 3 to 3:
```sh
$ kopia repository upgrade --password 12345678 --config-file /tmp/kopia/repository.config --upgrade-owner-id owner --io-drain-timeout 1s --status-poll-interval 1s --max-clock-drift 1s
ERROR error setting the upgrade lock intent: repository is already upgraded to 3, we can only upgrade till 3
```

Upgrading from format 2 to format 3:
```sh
$ kopia repository upgrade --password 12345678 --config-file /tmp/kopia/repository.config --upgrade-owner-id owner --io-drain-timeout 1s --status-poll-interval 1s --max-clock-drift 1s
Repository upgrade lock intent has been placed.
repository indices have already been migrated to the epoch format
Repository has been successfully upgraded
```

Non-owner upgraders during an upgrade:
```sh
$ kopia repository upgrade --password 12345678 --config-file /tmp/kopia/repository.config --upgrade-owner-id ownerx --io-drain-timeout 10s --status-poll-interval 5s --max-clock-drift 1s
ERROR failed to open repository: repository upgrade in progress
ERROR open repository: unable to open repository: repository upgrade in progress
```

Connections to repository during an upgrade:
```sh
$ kopia repository connect filesystem --password 12345678 --config-file /tmp/kopia/repository.config --path /tmp/kopia/repo/
ERROR failed to open repository: repository upgrade in progress
deleted repository password for /tmp/kopia/repository.config.
kopia: error: error connecting to repository: repository upgrade in progress, try --help
```

Upgrade status with advance notice:
```sh
$ kopia repository status --password 12345678 --config-file /tmp/kopia/repository.config --upgrade-owner-id owner
Config file:         /tmp/kopia/repository.config

Description:         Repository in Filesystem: /tmp/kopia/repo
Hostname:            c02fq0ttmd6r
Username:            shikhar.mall
Read-only:           false
Format blob cache:   15m0s

Storage type:        filesystem
Storage config:      {
                       "path": "/tmp/kopia/repo",
                       "fileMode": 384,
                       "dirMode": 448,
                       "dirShards": [
                         3,
                         3
                       ]
                     }

Unique ID:           83e7ec60180d56181c979213b22b9401c3709d1fcac1a2b2d9d8b921940e0c7e
Hash:                BLAKE2B-256-128
Encryption:          AES256-GCM-HMAC-SHA256
Splitter:            DYNAMIC-4M-BUZHASH
Format version:      3
Content compression: false
Password changes:    false
Max pack length:     20 MiB
Index Format:        v1
Epoch Manager:       disabled
Ongoing upgrade:     Format Version 3 -> 3
Upgrade Time:        2021-12-22 17:05:27.98409 -0800 PST
Upgrade lock:        Unlocked
Lock status:         Draining
```

Upgrade status with immediate lock:
```sh
$ kopia repository status --password 12345678 --config-file /tmp/kopia/repository.config --upgrade-owner-id owner
Config file:         /tmp/kopia/repository.config

Description:         Repository in Filesystem: /tmp/kopia/repo
Hostname:            c02fq0ttmd6r
Username:            shikhar.mall
Read-only:           false
Format blob cache:   15m0s

Storage type:        filesystem
Storage config:      {
                       "path": "/tmp/kopia/repo",
                       "fileMode": 384,
                       "dirMode": 448,
                       "dirShards": [
                         3,
                         3
                       ]                                                                                                                                                                                                                                                                             }

Unique ID:           83e7ec60180d56181c979213b22b9401c3709d1fcac1a2b2d9d8b921940e0c7e
Hash:                BLAKE2B-256-128
Encryption:          AES256-GCM-HMAC-SHA256
Splitter:            DYNAMIC-4M-BUZHASH
Format version:      3
Content compression: false
Password changes:    false
Max pack length:     20 MiB
Index Format:        v1
Epoch Manager:       disabled
Ongoing upgrade:     Format Version 1 -> 3
Upgrade Time:        2021-12-22 16:55:49.98409 -0800 PST
Upgrade lock:        Locked
Lock status:         Fully Established
```