### PR TITLE
s3/test: refactor retention tests

### DIFF
--- a/repo/blob/s3/s3_storage_test.go
+++ b/repo/blob/s3/s3_storage_test.go
@@ -225,28 +225,19 @@ func TestS3StorageAWSRetentionLockedBucket(t *testing.T) {
 	}
 
 	createBucket(t, options)
-	testStorage(t, options, false, blob.PutOptions{
-		RetentionMode:   minio.Governance.String(),
-		RetentionPeriod: time.Hour * 24,
+
+	t.Run("testStorage", func(t *testing.T) {
+		testStorage(t, options, false, blob.PutOptions{
+			RetentionMode:   minio.Governance.String(),
+			RetentionPeriod: time.Hour * 24,
+		})
 	})
-}
 
-func TestS3StorageAWSRetentionInvalidPeriodLockedBucket(t *testing.T) {
-	t.Parallel()
-
-	// skip the test if AWS creds are not provided
-	options := &Options{
-		Endpoint:        getEnv(testEndpointEnv, awsEndpoint),
-		AccessKeyID:     getEnvOrSkip(t, testAccessKeyIDEnv),
-		SecretAccessKey: getEnvOrSkip(t, testSecretAccessKeyEnv),
-		BucketName:      getEnvOrSkip(t, testLockedBucketEnv),
-		Region:          getEnvOrSkip(t, testRegionEnv),
-	}
-
-	createBucket(t, options)
-	testPutBlobWithInvalidRetention(t, options, blob.PutOptions{
-		RetentionMode:   minio.Governance.String(),
-		RetentionPeriod: time.Nanosecond,
+	t.Run("invalid period", func(t *testing.T) {
+		testPutBlobWithInvalidRetention(t, options, blob.PutOptions{
+			RetentionMode:   minio.Governance.String(),
+			RetentionPeriod: time.Nanosecond,
+		})
 	})
 }
 

--- a/repo/blob/s3/s3_storage_test.go
+++ b/repo/blob/s3/s3_storage_test.go
@@ -195,9 +195,20 @@ func TestS3StorageAWSRetentionUnlockedBucket(t *testing.T) {
 	}
 
 	createBucket(t, options)
-	testPutBlobWithInvalidRetention(t, options, blob.PutOptions{
-		RetentionMode:   minio.Governance.String(),
-		RetentionPeriod: time.Hour * 24,
+
+	t.Run("valid period", func(t *testing.T) {
+		// expected to fail on non-locked buckets
+		testPutBlobWithInvalidRetention(t, options, blob.PutOptions{
+			RetentionMode:   minio.Governance.String(),
+			RetentionPeriod: time.Hour * 24,
+		})
+	})
+
+	t.Run("invalid period", func(t *testing.T) {
+		testPutBlobWithInvalidRetention(t, options, blob.PutOptions{
+			RetentionMode:   minio.Governance.String(),
+			RetentionPeriod: time.Nanosecond,
+		})
 	})
 }
 
@@ -217,25 +228,6 @@ func TestS3StorageAWSRetentionLockedBucket(t *testing.T) {
 	testStorage(t, options, false, blob.PutOptions{
 		RetentionMode:   minio.Governance.String(),
 		RetentionPeriod: time.Hour * 24,
-	})
-}
-
-func TestS3StorageAWSRetentionInvalidPeriod(t *testing.T) {
-	t.Parallel()
-
-	// skip the test if AWS creds are not provided
-	options := &Options{
-		Endpoint:        getEnv(testEndpointEnv, awsEndpoint),
-		AccessKeyID:     getEnvOrSkip(t, testAccessKeyIDEnv),
-		SecretAccessKey: getEnvOrSkip(t, testSecretAccessKeyEnv),
-		BucketName:      getEnvOrSkip(t, testBucketEnv),
-		Region:          getEnvOrSkip(t, testRegionEnv),
-	}
-
-	createBucket(t, options)
-	testPutBlobWithInvalidRetention(t, options, blob.PutOptions{
-		RetentionMode:   minio.Governance.String(),
-		RetentionPeriod: time.Nanosecond,
 	})
 }
 

--- a/repo/blob/s3/s3_storage_test.go
+++ b/repo/blob/s3/s3_storage_test.go
@@ -182,7 +182,7 @@ func TestS3StorageAWSSTS(t *testing.T) {
 	testStorage(t, options, false, blob.PutOptions{})
 }
 
-func TestS3StorageAWSRetentionUnversionedBucket(t *testing.T) {
+func TestS3StorageAWSRetentionUnlockedBucket(t *testing.T) {
 	t.Parallel()
 
 	// skip the test if AWS creds are not provided


### PR DESCRIPTION
Refactors retention tests to coalesce a couple of tests. It has the following effects:
- serializes the tests;
- reuses the bucket and reduces bucket creation calls.

Also, checks whether a bucket exists before attempting to create it to reduce the number of bucket creation calls.