### PR TITLE
feat(providers): allow other GCS OAuth2.0 credential types (#3064)

### DIFF
--- a/repo/blob/gcs/gcs_internal_test.go
+++ b/repo/blob/gcs/gcs_internal_test.go
@@ -1,0 +1,80 @@
+// Package gcs implements Storage based on Google Cloud Storage bucket.
+package gcs
+
+import (
+	"context"
+	"io/fs"
+	"os"
+	"testing"
+
+	gcsclient "cloud.google.com/go/storage"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGCSStorageCredentialsHelpers(t *testing.T) {
+	ctx := context.Background()
+	scope := gcsclient.ScopeReadOnly
+
+	var fileMode fs.FileMode = 0o644
+
+	// Service Account key
+	gsaKeyServiceAccount := `{
+		"type": "service_account",
+		"project_id": "kopia-test-project",
+		"private_key_id": "kopia-test",
+		"private_key": "some-private-key",
+		"client_email": "kopia-test@developer.gserviceaccount.com",
+		"client_id": "kopia-test.apps.googleusercontent.com",
+		"auth_uri": "https://accounts.google.com/o/oauth2/auth",
+		"token_uri": "http://localhost:8080/token"
+	  }`
+	gsaKeyServiceAccountFileName := "service-account.json"
+	errWriteFile := os.WriteFile(gsaKeyServiceAccountFileName, []byte(gsaKeyServiceAccount), fileMode)
+	require.NoError(t, errWriteFile)
+	t.Cleanup(func() {
+		os.Remove(gsaKeyServiceAccountFileName)
+	})
+
+	t.Run("tokenSourceFromCredentialsJSON with service account key", func(t *testing.T) {
+		ts, err := tokenSourceFromCredentialsJSON(ctx, []byte(gsaKeyServiceAccount), scope)
+		require.NoError(t, err)
+		require.NotNil(t, ts)
+	})
+	t.Run("tokenSourceFromCredentialsFile with service account key file", func(t *testing.T) {
+		ts, err := tokenSourceFromCredentialsFile(ctx, gsaKeyServiceAccountFileName, scope)
+		require.NoError(t, err)
+		require.NotNil(t, ts)
+	})
+
+	// External Account key
+	gsaKeyExternalAccount := `{
+		"type": "external_account",
+		"audience": "some-audience",
+		"subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+		"token_url": "https://sts.googleapis.com/v1/token",
+		"service_account_impersonation_url": "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/kopia-test@kopia-test-project.iam.gserviceaccount.com:generateAccessToken",
+		"credential_source": {
+		  "file": "/var/run/secrets/serviceaccount/token",
+		  "format": {
+			"type": "text"
+		  }
+		}
+	  }`
+	gsaKeyExternalAccountFileName := "external-account.json"
+	errWriteFile = os.WriteFile(gsaKeyExternalAccountFileName, []byte(gsaKeyExternalAccount), fileMode)
+	require.NoError(t, errWriteFile)
+	t.Cleanup(func() {
+		os.Remove(gsaKeyExternalAccountFileName)
+	})
+
+	t.Run("tokenSourceFromCredentialsJSON with external account key", func(t *testing.T) {
+		ts, err := tokenSourceFromCredentialsJSON(ctx, []byte(gsaKeyExternalAccount), scope)
+		require.NoError(t, err)
+		require.NotNil(t, ts)
+	})
+	t.Run("tokenSourceFromCredentialsFile with external account key file", func(t *testing.T) {
+		ts, err := tokenSourceFromCredentialsFile(ctx, gsaKeyExternalAccountFileName, scope)
+		require.NoError(t, err)
+		require.NotNil(t, ts)
+	})
+}

--- a/repo/blob/gcs/gcs_storage.go
+++ b/repo/blob/gcs/gcs_storage.go
@@ -218,21 +218,16 @@ func tokenSourceFromCredentialsFile(ctx context.Context, fn string, scopes ...st
 		return nil, errors.Wrap(err, "error reading credentials file")
 	}
 
-	cfg, err := google.JWTConfigFromJSON(data, scopes...)
-	if err != nil {
-		return nil, errors.Wrap(err, "google.JWTConfigFromJSON")
-	}
-
-	return cfg.TokenSource(ctx), nil
+	return tokenSourceFromCredentialsJSON(ctx, data, scopes...)
 }
 
 func tokenSourceFromCredentialsJSON(ctx context.Context, data json.RawMessage, scopes ...string) (oauth2.TokenSource, error) {
-	cfg, err := google.JWTConfigFromJSON([]byte(data), scopes...)
+	creds, err := google.CredentialsFromJSON(ctx, data, scopes...)
 	if err != nil {
-		return nil, errors.Wrap(err, "google.JWTConfigFromJSON")
+		return nil, errors.Wrap(err, "google.CredentialsFromJSON")
 	}
 
-	return cfg.TokenSource(ctx), nil
+	return creds.TokenSource, nil
 }
 
 // New creates new Google Cloud Storage-backed storage with specified options:


### PR DESCRIPTION
This PR:

1. Revert the base back to commit https://github.com/kopia/kopia/commit/3551f743d762f2ffe669523272d1c8d734120b79
2. Bring in changes from https://github.com/kopia/kopia/pull/3064
> Change google client to accept more credentials type, including json config file for workload identity federation Refactor > tokenSourceFromCredentialsFile to remove duplicate code Add unit tests