### PR TITLE
Draft: perform index maintenance on repo maintenance

### DIFF
--- a/internal/epoch/epoch_manager.go
+++ b/internal/epoch/epoch_manager.go
@@ -288,6 +288,21 @@ func (e *Manager) maxCleanupTime(cs CurrentSnapshot) time.Time {
 	return maxTime
 }
 
+// CleanupMarkers removes superseded watermarks and epoch markers.
+func (e *Manager) CleanupMarkers(ctx context.Context) error {
+	cs, err := e.committedState(ctx, 0)
+	if err != nil {
+		return err
+	}
+
+	p, err := e.getParameters()
+	if err != nil {
+		return err
+	}
+
+	return e.cleanupInternal(ctx, cs, p)
+}
+
 func (e *Manager) cleanupInternal(ctx context.Context, cs CurrentSnapshot, p *Parameters) error {
 	eg, ctx := errgroup.WithContext(ctx)
 

--- a/internal/epoch/epoch_manager.go
+++ b/internal/epoch/epoch_manager.go
@@ -1067,6 +1067,57 @@ func getCompactedEpochRange(cs CurrentSnapshot) (intRange, error) {
 	return getKeyRange(cs.SingleEpochCompactionSets)
 }
 
+// MaybeCompactSingleEpoch compacts the oldest epoch that is elegible for
+// compaction if there is one.
+func (e *Manager) MaybeCompactSingleEpoch(ctx context.Context) error {
+	cs, err := e.committedState(ctx, 0)
+	if err != nil {
+		return err
+	}
+
+	uncompacted, err := getUncompactedEpochRange(cs)
+	if err != nil {
+		return err
+	}
+
+	if uncompacted.isEmpty() {
+		e.log.Debug("empty uncompacted epoch range, not compacting")
+		return nil
+	}
+
+	compacted, err := getCompactedEpochRange(cs)
+	if err != nil {
+		return err
+	}
+
+	if uncompacted.lo < compacted.hi {
+		uncompacted.lo = compacted.hi // avoid compacting already compacted epoch
+	}
+
+	if uncompacted.isEmpty() || !cs.isSettledEpochNumber(uncompacted.lo) {
+		e.log.Debug("there are no uncompacted epochs eligible for compaction")
+
+		return nil
+	}
+
+	epochToCompact := uncompacted.lo
+
+	uncompactedBlobs, ok := cs.UncompactedEpochSets[epochToCompact]
+	if !ok {
+		e.log.Debugf("there are no uncompacted blobs for epoch %d, not compacting", epochToCompact)
+
+		return nil
+	}
+
+	e.log.Debugf("starting single-epoch compaction of %v")
+
+	if err := e.compact(ctx, blob.IDsFromMetadata(uncompactedBlobs), compactedEpochBlobPrefix(epochToCompact)); err != nil {
+		return errors.Wrapf(err, "unable to compact blobs for epoch %v: performance will be affected", epochToCompact)
+	}
+
+	return nil
+}
+
 func (e *Manager) getIndexesFromEpochInternal(ctx context.Context, cs CurrentSnapshot, epoch int) ([]blob.Metadata, error) {
 	// check if the epoch is old enough to possibly have compacted blobs
 	epochSettled := cs.isSettledEpochNumber(epoch)

--- a/internal/epoch/epoch_manager_test.go
+++ b/internal/epoch/epoch_manager_test.go
@@ -739,6 +739,70 @@ func TestValidateParameters(t *testing.T) {
 	}
 }
 
+func TestGetKeyRange(t *testing.T) {
+	cases := []struct {
+		input     map[int]bool
+		want      intRange
+		shouldErr bool
+	}{
+		{},
+		{
+			input: map[int]bool{-5: true},
+			want:  intRange{lo: -5, hi: -4},
+		},
+		{
+			input: map[int]bool{-5: true, -4: true},
+			want:  intRange{lo: -5, hi: -3},
+		},
+		{
+			input: map[int]bool{0: true},
+			want:  intRange{lo: 0, hi: 1},
+		},
+		{
+			input: map[int]bool{5: true},
+			want:  intRange{lo: 5, hi: 6},
+		},
+		{
+			input: map[int]bool{0: true, 1: true},
+			want:  intRange{lo: 0, hi: 2},
+		},
+		{
+			input: map[int]bool{8: true, 9: true},
+			want:  intRange{lo: 8, hi: 10},
+		},
+		{
+			input: map[int]bool{1: true, 2: true, 3: true, 4: true, 5: true},
+			want:  intRange{lo: 1, hi: 6},
+		},
+		{
+			input:     map[int]bool{8: true, 10: true},
+			want:      intRange{lo: -1, hi: -1},
+			shouldErr: true,
+		},
+		{
+			input:     map[int]bool{1: true, 2: true, 3: true, 5: true},
+			want:      intRange{lo: -1, hi: -1},
+			shouldErr: true,
+		},
+		{
+			input:     map[int]bool{-5: true, -7: true},
+			want:      intRange{lo: -1, hi: -1},
+			shouldErr: true,
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprint("case: ", i), func(t *testing.T) {
+			got, err := getKeyRange(tc.input)
+			if tc.shouldErr {
+				require.Error(t, err)
+			}
+
+			require.Equal(t, tc.want, got, "input: %#v", tc.input)
+		})
+	}
+}
+
 func randomTime(min, max time.Duration) time.Duration {
 	return time.Duration(float64(max-min)*rand.Float64() + float64(min))
 }

--- a/repo/maintenance/maintenance_run.go
+++ b/repo/maintenance/maintenance_run.go
@@ -50,6 +50,7 @@ const (
 	TaskEpochDeleteSupersededIndexes = "delete-superseded-epoch-indexes"
 	TaskEpochCleanupMarkers          = "cleanup-epoch-markers"
 	TaskEpochGenerateRange           = "generate-epoch-range-index"
+	TaskEpochCompactSingle           = "compact-single-epoch"
 )
 
 // shouldRun returns Mode if repository is due for periodic maintenance.
@@ -350,6 +351,14 @@ func runTaskEpochMaintenanceQuick(ctx context.Context, runParams RunParameters, 
 
 	if !hasEpochManager {
 		return nil
+	}
+
+	err := ReportRun(ctx, runParams.rep, TaskEpochCompactSingle, s, func() error {
+		log(ctx).Infof("Compacting an eligible uncompacted epoch...")
+		return errors.Wrap(em.MaybeCompactSingleEpoch(ctx), "error compacting single epoch")
+	})
+	if err != nil {
+		return err
 	}
 
 	return runTaskEpochAdvance(ctx, em, runParams, s)

--- a/repo/maintenance/maintenance_run.go
+++ b/repo/maintenance/maintenance_run.go
@@ -46,6 +46,7 @@ const (
 	TaskExtendBlobRetentionTimeFull  = "extend-blob-retention-time"
 	TaskCleanupLogs                  = "cleanup-logs"
 	TaskEpochDeleteSupersededIndexes = "delete-superseded-epoch-indexes"
+	TaskEpochCleanupMarkers          = "cleanup-epoch-markers"
 )
 
 // shouldRun returns Mode if repository is due for periodic maintenance.
@@ -335,6 +336,16 @@ func runTaskEpochMaintenanceFull(ctx context.Context, runParams RunParameters, s
 
 	if !ok {
 		return nil
+	}
+
+	// clean up epoch markers
+	err := ReportRun(ctx, runParams.rep, TaskEpochCleanupMarkers, s, func() error {
+		log(ctx).Infof("Cleaning up unneeded epoch markers...")
+
+		return errors.Wrap(em.CleanupMarkers(ctx), "error removing epoch markers")
+	})
+	if err != nil {
+		return err
 	}
 
 	return ReportRun(ctx, runParams.rep, TaskEpochDeleteSupersededIndexes, s, func() error {

--- a/repo/maintenance/maintenance_run.go
+++ b/repo/maintenance/maintenance_run.go
@@ -36,16 +36,16 @@ type TaskType string
 
 // Task IDs.
 const (
-	TaskSnapshotGarbageCollection   = "snapshot-gc"
-	TaskDeleteOrphanedBlobsQuick    = "quick-delete-blobs"
-	TaskDeleteOrphanedBlobsFull     = "full-delete-blobs"
-	TaskRewriteContentsQuick        = "quick-rewrite-contents"
-	TaskRewriteContentsFull         = "full-rewrite-contents"
-	TaskDropDeletedContentsFull     = "full-drop-deleted-content"
-	TaskIndexCompaction             = "index-compaction"
-	TaskExtendBlobRetentionTimeFull = "extend-blob-retention-time"
-	TaskCleanupLogs                 = "cleanup-logs"
-	TaskCleanupEpochManager         = "cleanup-epoch-manager"
+	TaskSnapshotGarbageCollection    = "snapshot-gc"
+	TaskDeleteOrphanedBlobsQuick     = "quick-delete-blobs"
+	TaskDeleteOrphanedBlobsFull      = "full-delete-blobs"
+	TaskRewriteContentsQuick         = "quick-rewrite-contents"
+	TaskRewriteContentsFull          = "full-rewrite-contents"
+	TaskDropDeletedContentsFull      = "full-drop-deleted-content"
+	TaskIndexCompaction              = "index-compaction"
+	TaskExtendBlobRetentionTimeFull  = "extend-blob-retention-time"
+	TaskCleanupLogs                  = "cleanup-logs"
+	TaskEpochDeleteSupersededIndexes = "delete-superseded-epoch-indexes"
 )
 
 // shouldRun returns Mode if repository is due for periodic maintenance.
@@ -327,7 +327,7 @@ func runTaskCleanupLogs(ctx context.Context, runParams RunParameters, s *Schedul
 	})
 }
 
-func runTaskCleanupEpochManager(ctx context.Context, runParams RunParameters, s *Schedule) error {
+func runTaskEpochMaintenanceFull(ctx context.Context, runParams RunParameters, s *Schedule) error {
 	em, ok, emerr := runParams.rep.ContentManager().EpochManager()
 	if emerr != nil {
 		return errors.Wrap(emerr, "epoch manager")
@@ -337,9 +337,9 @@ func runTaskCleanupEpochManager(ctx context.Context, runParams RunParameters, s 
 		return nil
 	}
 
-	return ReportRun(ctx, runParams.rep, TaskCleanupEpochManager, s, func() error {
+	return ReportRun(ctx, runParams.rep, TaskEpochDeleteSupersededIndexes, s, func() error {
 		log(ctx).Infof("Cleaning up old index blobs which have already been compacted...")
-		return errors.Wrap(em.CleanupSupersededIndexes(ctx), "error cleaning up superseded index blobs")
+		return errors.Wrap(em.CleanupSupersededIndexes(ctx), "error removing superseded epoch index blobs")
 	})
 }
 
@@ -449,7 +449,7 @@ func runFullMaintenance(ctx context.Context, runParams RunParameters, safety Saf
 		log(ctx).Debug("Extending object lock retention-period is disabled.")
 	}
 
-	if err := runTaskCleanupEpochManager(ctx, runParams, s); err != nil {
+	if err := runTaskEpochMaintenanceFull(ctx, runParams, s); err != nil {
 		return errors.Wrap(err, "error cleaning up epoch manager")
 	}
 


### PR DESCRIPTION
Early draft with partial implementation

- [x] Cleanup watermark and epoch markers on full maintenance
- [x] Advance epoch on quick maintenance
- [x] Advance epoch on full maintenance
- [x] Compact a single epoch on quick maintenance
- [x] Range compaction on full maintenance
- [ ] Epoch compaction for all elegible epochs on full maintenance
