### PR TITLE
Do not merge: POC initialization/shutdown hooks for pprof logging

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kopia/kopia/internal/apiclient"
 	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/internal/passwordpersist"
+	"github.com/kopia/kopia/internal/profilelog"
 	"github.com/kopia/kopia/internal/releasable"
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/blob"
@@ -489,6 +490,9 @@ func (c *App) runAppWithContext(command *kingpin.CmdClause, cb func(ctx context.
 	if err := c.observability.startMetrics(ctx); err != nil {
 		return errors.Wrap(err, "unable to start metrics")
 	}
+
+	s := profilelog.MaybeStart(ctx)
+	defer s.Stop(ctx)
 
 	err := func() error {
 		tctx, span := tracer.Start(ctx, command.FullCommand(), trace.WithSpanKind(trace.SpanKindClient))

--- a/internal/profilelog/dumpsignal.go
+++ b/internal/profilelog/dumpsignal.go
@@ -1,0 +1,8 @@
+//go:build !windows
+// +build !windows
+
+package profilelog
+
+import "syscall"
+
+const dumpSignal = syscall.SIGUSR1

--- a/internal/profilelog/dumpsignal_windows.go
+++ b/internal/profilelog/dumpsignal_windows.go
@@ -1,0 +1,5 @@
+package profilelog
+
+import "syscall"
+
+const dumpSignal = syscall.SIGQUIT

--- a/internal/profilelog/profilelog.go
+++ b/internal/profilelog/profilelog.go
@@ -1,0 +1,49 @@
+// Package profilelog implements functionality for writing pprof profiles to logs.
+package profilelog
+
+import (
+	"context"
+	"os"
+	"os/signal"
+
+	"github.com/kopia/kopia/debug"
+	"github.com/kopia/kopia/internal/ctxutil"
+)
+
+type stopper func(ctx context.Context)
+
+func (s stopper) Stop(ctx context.Context) {
+	s(ctx)
+}
+
+// MaybeStart may start the ability to send pprof buffers to the logs.
+// The caller must call `v.Stop()` to finish profiling and dump the logs
+func MaybeStart(ctx context.Context) interface {
+	Stop(ctx context.Context)
+} {
+	if os.Getenv(debug.EnvVarKopiaDebugPprof) == "" {
+		// no need to configure anything, thus nothing needs to be stopped.
+		return stopper(func(context.Context) {})
+	}
+
+	debug.StartProfileBuffers(ctx)
+	setupDumpSignalHandler(ctx)
+
+	return stopper(debug.StopProfileBuffers)
+}
+
+func setupDumpSignalHandler(ctx context.Context) {
+	s := make(chan os.Signal, 1)
+
+	signal.Notify(s, dumpSignal)
+
+	go func() {
+		dctx := ctxutil.Detach(ctx)
+
+		for {
+			<-s
+			debug.StopProfileBuffers(dctx)
+			debug.StartProfileBuffers(dctx)
+		}
+	}()
+}


### PR DESCRIPTION
This covers all the practical use cases for initialization and termination.