### PR TITLE
feat(cli): c2: PPROF extensions

### DIFF
--- a/internal/pproflogging/pproflogging.go
+++ b/internal/pproflogging/pproflogging.go
@@ -2,9 +2,14 @@
 package pproflogging
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"encoding/pem"
 	"errors"
+	"fmt"
+	"io"
+	"os"
 	"strings"
 	"sync"
 
@@ -33,13 +38,10 @@ const (
 	EnvVarKopiaDebugPprof = "KOPIA_PPROF_LOGGING_CONFIG"
 )
 
+// flags used to configure profiling in EnvVarKopiaDebugPprof.
 const (
-	// ProfileNameBlock block profile key.
-	ProfileNameBlock ProfileName = "block"
-	// ProfileNameMutex mutex profile key.
-	ProfileNameMutex = "mutex"
-	// ProfileNameCPU cpu profile key.
-	ProfileNameCPU = "cpu"
+	// KopiaDebugFlagDebug value of the profiles `debug` parameter.
+	KopiaDebugFlagDebug = "debug"
 )
 
 var (
@@ -49,12 +51,19 @@ var (
 	ErrEmptyProfileName = errors.New("empty profile flag")
 
 	//nolint:gochecknoglobals
-	pprofConfigs = newProfileConfigs()
+	pprofConfigs = newProfileConfigs(os.Stderr)
 )
+
+// Writer interface supports destination for PEM output.
+type Writer interface {
+	io.Writer
+	io.StringWriter
+}
 
 // ProfileConfigs configuration flags for all requested profiles.
 type ProfileConfigs struct {
 	mu  sync.Mutex
+	wrt Writer
 	pcm map[ProfileName]*ProfileConfig
 }
 
@@ -66,10 +75,34 @@ func HasProfileBuffersEnabled() bool {
 	return len(pprofConfigs.pcm) != 0
 }
 
-func newProfileConfigs() *ProfileConfigs {
-	q := &ProfileConfigs{}
+func newProfileConfigs(wrt Writer) *ProfileConfigs {
+	q := &ProfileConfigs{
+		wrt: wrt,
+	}
 
 	return q
+}
+
+// SetWriter set the destination for the PPROF dump.
+// +checklocksignore.
+func (p *ProfileConfigs) SetWriter(wrt Writer) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.wrt = wrt
+}
+
+// GetProfileConfig return a profile configuration by name.
+// +checklocksignore.
+func (p *ProfileConfigs) GetProfileConfig(nm ProfileName) *ProfileConfig {
+	if p == nil {
+		return nil
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return p.pcm[nm]
 }
 
 // LoadProfileConfig configure PPROF profiling from the config in ppconfigss.
@@ -159,3 +192,105 @@ func newProfileConfig(bufSizeB int, ppconfig string) *ProfileConfig {
 	return q
 }
 
+// DumpPem dump a PEM version of the byte slice, bs, into writer, wrt.
+// DumpPem performs the PEM dump in two goroutines: the first (the main
+// execution thread) performs the output to the console (see notes below).
+// The second gorouting encodes []byte into PEM format.
+//
+// The advantage of using two goroutines is a simpler implementation
+// and better utilization of Go library functions.
+// The implementation could be single threaded (unrolling the io.Pipe into
+// a single thread), but the utilization of the bufio buffer then becomes
+// convoluted (or a custom temporary buffer needs to be allocated).
+func DumpPem(ctx context.Context, bs []byte, types string, wrt Writer) error {
+	blk := &pem.Block{
+		Type:  types,
+		Bytes: bs,
+	}
+	// wrt is likely a line oriented writer, so writing individual lines
+	// will make best use of output buffer and help prevent overflows or
+	// stalls in the output path.
+	pr, pw := io.Pipe()
+
+	// ensure that the reader is closed on exit
+	defer func() {
+		err := pr.Close()
+		if err != nil {
+			log(ctx).Errorf("error closing PEM buffer: %w", err)
+		}
+	}()
+
+	// start a writer in the background.  This writes encoded PEMs while there's data.
+	go func() {
+		// do the encoding
+		err0 := pem.Encode(pw, blk)
+		if err0 != nil {
+			log(ctx).Errorf("could not write PEM: %w", err0)
+		}
+
+		// writer close on exit of background process
+		err := pw.Close()
+		if err != nil {
+			// print error but do not exit
+			log(ctx).Errorf("error closing PEM buffer: %w", err)
+		}
+	}()
+
+	// connect rdr to pipe reader
+	rdr := bufio.NewReader(pr)
+
+	// err1 for reading
+	// err2 for writing
+	// err3 for context
+	var err1, err2, err3 error
+	err3 = ctx.Err()
+
+	// A missed line or partial line in console output will result in a corrupted PEM.
+	// Because of this, it is important that output conform to external loggers,
+	// especially Kubernetes.
+	// this code ensures that output occurs in a line oriented way so that there are
+	// no broken lines or missing terminal lines.
+	//
+	// output as long as there are no:
+	// - errors writing to the log
+	// - reading from the pem encodings
+	// - canceled contexts
+	//
+	for err1 == nil && err2 == nil && err3 == nil {
+		var ln []byte
+		ln, err1 = rdr.ReadBytes('\n')
+		// err1 can return ln and non-nil err1, so always call write
+		_, err2 = wrt.Write(ln)
+		err3 = ctx.Err()
+	}
+
+	// be nice, tell everyone of any problems.
+
+	// got a context error.  this has precedent
+	if err3 != nil {
+		return fmt.Errorf("could not write PEM: %w", err3)
+	}
+
+	// got a write error.
+	if err2 != nil {
+		return fmt.Errorf("could not write PEM: %w", err2)
+	}
+
+	// did not get a read error.  file ends in newline
+	if err1 == nil {
+		return nil
+	}
+
+	// if file does not end in newline, then output one.
+	// this prevents truncated output
+	if errors.Is(err1, io.EOF) {
+		_, err2 = wrt.WriteString("\n")
+		if err2 != nil {
+			return fmt.Errorf("could not write PEM: %w", err2)
+		}
+
+		return nil
+	}
+
+	return fmt.Errorf("error reading bytes: %w", err1)
+}

--- a/internal/pproflogging/pproflogging_test.go
+++ b/internal/pproflogging/pproflogging_test.go
@@ -1,8 +1,10 @@
 package pproflogging
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"sync"
 	"testing"
@@ -173,6 +175,18 @@ func TestDebug_newProfileConfigs(t *testing.T) {
 	}
 }
 
+func TestDebug_DumpPem(t *testing.T) {
+	saveLockEnv(t)
+	defer restoreUnlockEnv(t)
+
+	ctx := context.Background()
+	wrt := bytes.Buffer{}
+	// DumpPem dump a PEM version of the byte slice, bs, into writer, wrt.
+	err := DumpPem(ctx, []byte("this is a sample PEM"), "test", &wrt)
+	require.NoError(t, err)
+	require.Equal(t, "-----BEGIN test-----\ndGhpcyBpcyBhIHNhbXBsZSBQRU0=\n-----END test-----\n\n", wrt.String())
+}
+
 func TestDebug_LoadProfileConfigs(t *testing.T) {
 	// save environment and restore after testing
 	saveLockEnv(t)
@@ -298,3 +312,38 @@ func restoreUnlockEnv(t *testing.T) {
 	mu.Unlock()
 }
 
+func TestWriter(t *testing.T) {
+	eww := &ErrorWriter{mx: 5, err: io.EOF}
+	n, err := eww.WriteString("Hello World")
+	require.ErrorIs(t, io.EOF, err)
+	require.Equal(t, 5, n)
+	require.Equal(t, "Hello", string(eww.bs))
+}
+
+type ErrorWriter struct {
+	bs  []byte
+	mx  int
+	err error
+}
+
+func (p *ErrorWriter) Write(bs []byte) (int, error) {
+	lbs := len(bs)
+	lpbs := len(p.bs)
+	n := lbs
+
+	if lbs+lpbs > p.mx {
+		n = p.mx - lpbs
+	}
+
+	p.bs = append(p.bs, bs[:n]...)
+	if n < lbs {
+		return n, p.err
+	}
+
+	return n, nil
+}
+
+//nolint:gocritic
+func (p *ErrorWriter) WriteString(s string) (int, error) {
+	return p.Write([]byte(s))
+}


### PR DESCRIPTION
This PR adds the ability to dump pprof data to logs for debugging. 

This is a continuation of https://github.com/kopia/kopia/pull/3454

This is one of 8 PRs in a PR train:
`aaron-kasten/kopia:pprof-extensions-c1a`
`aaron-kasten/kopia:pprof-extensions-c1b`
`aaron-kasten/kopia:pprof-extensions-c2`
`aaron-kasten/kopia:pprof-extensions-c3`
`aaron-kasten/kopia:pprof-extensions-c4`
`aaron-kasten/kopia:pprof-extensions-c5`
`aaron-kasten/kopia:pprof-extensions-c6`
`aaron-kasten/kopia:pprof-extensions-c7`

Usage
=====

pprof dumps are configured using the `KOPIA_DEBUG_PPROF` environment variable.  The variable is a list of pprof profile names (see `pprof.Lookup`) separated by `,`.  Optional parameters can be set with '=', delimited by ':'.

example:

`export KOPIA_DEBUG_PPROF=cpu,heap=debug=1,mutex=debug=1:rate=1000`

The above setting will produce CPU, heap and mutex profiles.  The block profile will have its debug parameter set to 1 and its sample rate set to 1000



Once run, profile data will be output in the Kopia logs on termination.  Profile dumps are generated as base64 output (PEM) to the log on termination.

You should consider captureing logs to a file when running the Kopia command:

```
$ kopia --log-file ./myout.log snapshot create . &
[1] 77308
```

Once the logs are captured, a dump can created by terminating the command:

```
$ kill %1
```

The following signals (on Linux and macos) can be used to dump profiles: SIGTERM, SIGINT, and SIGUSR1.

Captured standard-output should look similar to:

```
saving PEM buffers for output
2021/11/16 19:38:59 Shutting down...
dumping PEM for "PPROF MEM"
-----BEGIN PPROF MEM-----
H4sIAAAAAAAE/7R8CXxURfIw3ZOEJkTTGUUK8Hg8FZMoM8kDBHTXlUtFPBDwWteN
w+RlGJnMG2cmIO7uf4PcN8qtcsqNXCIgghgQBMUL8RYVFPHAAw/UVdTvV9VvzswE
.
.
.
sOBRWRMwE4RCnvDAimrjlBhatdcTCGSqZ9kAbk+k2i4YRBLMVXsCvgQzQXNwKGzh
l3HYSLE3drEgweOQCN7Jjnq8A43CtKt5Rt5tgyoj1u1G/m2DIkMiXk8gcPv/CwAA
//8psEjOrZ4AAA==
-----END PPROF MEM-----
```

The captured output can then be converted to a pprof binary by using `kats`.  The Kopia `kats` tool can be used to convert the PEM file into a binary:

```
$ ./go/bin/kats dump.b64
writing PEM "PPROF MEM" to file "pprof_mem.bin"
```

When successful, kats will output the file found in the capture file.

kats expects that there is a well formed PEM record in the capture file.

```
 ./go/bin/kats --help
 Usage of ./go/bin/kats:
  -verbose
    	verbose outout
```

Once successful, the binary can be used in PPROF:

```
$ go tool pprof ./pprof_mem.bin
File: pprof_mem.bin
Type: inuse_space
Time: Nov 16, 2021 at 11:38am (PST)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) tree
Showing nodes accounting for 35248.89kB, 100% of 35248.89kB total
Showing top 80 nodes out of 127
----------------------------------------------------------+-------------
      flat  flat%   sum%        cum   cum%   calls calls% + context
----------------------------------------------------------+-------------
   16384kB 46.48% 46.48%    16384kB 46.48%                | kopia/tracing.StartProfileBuffers
----------------------------------------------------------+-------------
                                         2561.41kB   100% |   encoding/json.(*decodeState).object
 2561.41kB  7.27% 53.75%  2561.41kB  7.27%                | reflect.mapassign
```

Configuration Options
=====

TBDThis PR adds the ability to dump pprof data to logs for debugging. 

This is a continuation of https://github.com/kopia/kopia/pull/3454

This is one of 4 PRs in a PR train:
`aaron-kasten/kopia:pprof-extensions-A`
`aaron-kasten/kopia:pprof-extensions-B`
`aaron-kasten/kopia:pprof-extensions-C`
`aaron-kasten/kopia:pprof-extensions-D`

Usage
=====

pprof dumps are configured using the `KOPIA_DEBUG_PPROF` environment variable.  The variable is a list of pprof profile names (see `pprof.Lookup`) separated by `,`.  Optional parameters can be set with '=', delimited by ':'.

example:

`export KOPIA_DEBUG_PPROF=cpu,heap=debug=1,mutex=debug=1:rate=1000`

The above setting will produce CPU, heap and mutex profiles.  The block profile will have its debug parameter set to 1 and its sample rate set to 1000



Once run, profile data will be output in the Kopia logs on termination.  Profile dumps are generated as base64 output (PEM) to the log on termination.

You should consider captureing logs to a file when running the Kopia command:

```
$ kopia --log-file ./myout.log snapshot create . &
[1] 77308
```

Once the logs are captured, a dump can created by terminating the command:

```
$ kill %1
```

The following signals (on Linux and macos) can be used to dump profiles: SIGTERM, SIGINT, and SIGUSR1.

Captured standard-output should look similar to:

```
saving PEM buffers for output
2021/11/16 19:38:59 Shutting down...
dumping PEM for "PPROF MEM"
-----BEGIN PPROF MEM-----
H4sIAAAAAAAE/7R8CXxURfIw3ZOEJkTTGUUK8Hg8FZMoM8kDBHTXlUtFPBDwWteN
w+RlGJnMG2cmIO7uf4PcN8qtcsqNXCIgghgQBMUL8RYVFPHAAw/UVdTvV9VvzswE
.
.
.
sOBRWRMwE4RCnvDAimrjlBhatdcTCGSqZ9kAbk+k2i4YRBLMVXsCvgQzQXNwKGzh
l3HYSLE3drEgweOQCN7Jjnq8A43CtKt5Rt5tgyoj1u1G/m2DIkMiXk8gcPv/CwAA
//8psEjOrZ4AAA==
-----END PPROF MEM-----
```

The captured output can then be converted to a pprof binary by using `kats`.  The Kopia `kats` tool can be used to convert the PEM file into a binary:

```
$ ./go/bin/kats dump.b64
writing PEM "PPROF MEM" to file "pprof_mem.bin"
```

When successful, kats will output the file found in the capture file.

kats expects that there is a well formed PEM record in the capture file.

```
 ./go/bin/kats --help
 Usage of ./go/bin/kats:
  -verbose
    	verbose outout
```

Once successful, the binary can be used in PPROF:

```
$ go tool pprof ./pprof_mem.bin
File: pprof_mem.bin
Type: inuse_space
Time: Nov 16, 2021 at 11:38am (PST)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) tree
Showing nodes accounting for 35248.89kB, 100% of 35248.89kB total
Showing top 80 nodes out of 127
----------------------------------------------------------+-------------
      flat  flat%   sum%        cum   cum%   calls calls% + context
----------------------------------------------------------+-------------
   16384kB 46.48% 46.48%    16384kB 46.48%                | kopia/tracing.StartProfileBuffers
----------------------------------------------------------+-------------
                                         2561.41kB   100% |   encoding/json.(*decodeState).object
 2561.41kB  7.27% 53.75%  2561.41kB  7.27%                | reflect.mapassign
```

Configuration Options
=====

TBD
