### PR TITLE
fix(server): no maintenance task on read-only repo

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -632,11 +632,7 @@ func (s *Server) SetRepository(ctx context.Context, rep repo.Repository) error {
 		return err
 	}
 
-	if dr, ok := s.rep.(repo.DirectRepository); ok {
-		s.maint = startMaintenanceManager(ctx, dr, s, s.options.MinMaintenanceInterval)
-	} else {
-		s.maint = nil
-	}
+	s.maint = startMaintenanceManager(ctx, s.rep, s, s.options.MinMaintenanceInterval)
 
 	s.sched = scheduler.Start(context.WithoutCancel(ctx), s.getSchedulerItems, scheduler.Options{
 		TimeNow:        clock.Now,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -632,7 +632,7 @@ func (s *Server) SetRepository(ctx context.Context, rep repo.Repository) error {
 		return err
 	}
 
-	s.maint = startMaintenanceManager(ctx, s.rep, s, s.options.MinMaintenanceInterval)
+	s.maint = maybeStartMaintenanceManager(ctx, s.rep, s, s.options.MinMaintenanceInterval)
 
 	s.sched = scheduler.Start(context.WithoutCancel(ctx), s.getSchedulerItems, scheduler.Options{
 		TimeNow:        clock.Now,

--- a/internal/server/server_maintenance.go
+++ b/internal/server/server_maintenance.go
@@ -110,7 +110,8 @@ func (s *srvMaintenance) nextMaintenanceTime() time.Time {
 	return s.cachedNextMaintenanceTime
 }
 
-func startMaintenanceManager(
+// Starts a periodic, background srvMaintenance task. Returns nil if no task was created.
+func maybeStartMaintenanceManager(
 	ctx context.Context,
 	rep repo.Repository,
 	srv maintenanceManagerServerInterface,

--- a/internal/server/server_maintenance_test.go
+++ b/internal/server/server_maintenance_test.go
@@ -75,7 +75,7 @@ func TestServerMaintenance(t *testing.T) {
 
 	ts := &testServer{log: t.Logf}
 
-	mm := startMaintenanceManager(ctx, env.RepositoryWriter, ts, time.Minute)
+	mm := maybeStartMaintenanceManager(ctx, env.RepositoryWriter, ts, time.Minute)
 	require.Equal(t, time.Time{}, mm.nextMaintenanceNoEarlierThan)
 
 	defer mm.stop(ctx)
@@ -134,7 +134,7 @@ func TestServerMaintenanceReadOnlyRepoConnection(t *testing.T) {
 	env.MustReopen(t)
 
 	ts := &testServer{log: t.Logf}
-	mm := startMaintenanceManager(ctx, env.RepositoryWriter, ts, time.Minute)
+	mm := maybeStartMaintenanceManager(ctx, env.RepositoryWriter, ts, time.Minute)
 
 	require.Nil(t, mm, "maintenance task should not be created on read-only repo")
 }

--- a/snapshot/snapshotmaintenance/snapshotmaintenance.go
+++ b/snapshot/snapshotmaintenance/snapshotmaintenance.go
@@ -13,6 +13,10 @@ import (
 
 // Run runs the complete snapshot and repository maintenance.
 func Run(ctx context.Context, dr repo.DirectRepositoryWriter, mode maintenance.Mode, force bool, safety maintenance.SafetyParameters) error {
+	if dr.ClientOptions().ReadOnly {
+		return errors.New("not running maintenance on read-only repository connection")
+	}
+
 	//nolint:wrapcheck
 	return maintenance.RunExclusive(ctx, dr, mode, force,
 		func(ctx context.Context, runParams maintenance.RunParameters) error {


### PR DESCRIPTION
Avoid starting a maintenance task on the server when the repository connection (configuration) is read-only.

Ref:
- #4373