### PR TITLE
fix(server): limit allowed body size in server requests

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -358,11 +358,13 @@ func (s *Server) handleUIPossiblyNotConnected(f apiRequestFunc) http.HandlerFunc
 }
 
 func (s *Server) handleRequestPossiblyNotConnected(isAuthorized isAuthorizedFunc, checkCSRFToken csrfTokenOption, f apiRequestFunc) http.HandlerFunc {
+	const maxRequestBodySizeBytes = 4096
+
 	return s.requireAuth(checkCSRFToken, func(ctx context.Context, rc requestContext) {
 		// we must pre-read request body before acquiring the lock as it sometimes leads to deadlock
 		// in HTTP/2 server.
 		// See https://github.com/golang/go/issues/40816
-		body, berr := io.ReadAll(rc.req.Body)
+		body, berr := io.ReadAll(http.MaxBytesReader(rc.w, rc.req.Body, maxRequestBodySizeBytes))
 		if berr != nil {
 			http.Error(rc.w, "error reading request body", http.StatusInternalServerError)
 			return


### PR DESCRIPTION
Rationale: avoid unbounded resource consumption.